### PR TITLE
Added ability to pass plugin options

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -39,6 +39,17 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "kwelch",
+      "name": "Kyle Welch",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/1295580?v=3",
+      "profile": "http://www.krwelch.com",
+      "contributions": [
+        "code",
+        "doc",
+        "test"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Utilities for testing babel plugins
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -94,6 +94,11 @@ function identifierReversePlugin() {
 This is used for the `describe` title as well as the test titles. If it
 can be inferred from the `plugin`'s `name` then it will be and you don't need
 to provide this option.
+
+#### pluginOptions
+
+This can be used to pass options into your plugin at transform time. This option
+can be overwritten using the test object.
 
 #### title
 
@@ -247,6 +252,11 @@ pluginTester({
   // defaults to the plugin name
   title: 'describe block title',
 
+  // used to test specific plugin options
+  pluginOptions: {
+    optionA: true,
+  },
+
   // only necessary if you use fixture or outputFixture in your tests
   filename: __filename,
 
@@ -316,6 +326,14 @@ pluginTester({
       // easier to understand.
       snapshot: true,
     },
+    {
+      code: 'var hello = "hi";',
+      output: 'var olleh = "hi";',
+      // this can be used to overwrite the setting set above
+      pluginOptions: {
+        optionA: false,
+      },
+    },
   ],
 })
 ```
@@ -362,8 +380,8 @@ here!
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Tests") | [<img src="https://avatars3.githubusercontent.com/u/952783?v=3" width="100px;"/><br /><sub>james kyle</sub>](http://thejameskyle.com/)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Documentation") [👀](#review-thejameskyle "Reviewed Pull Requests") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Tests") | [<img src="https://avatars1.githubusercontent.com/u/1894628?v=3" width="100px;"/><br /><sub>Brad Bohen</sub>](https://github.com/bbohen)<br />[🐛](https://github.com/babel-utils/babel-plugin-tester/issues?q=author%3Abbohen "Bug reports") |
-| :---: | :---: | :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Tests") | [<img src="https://avatars3.githubusercontent.com/u/952783?v=3" width="100px;"/><br /><sub>james kyle</sub>](http://thejameskyle.com/)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Documentation") [👀](#review-thejameskyle "Reviewed Pull Requests") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Tests") | [<img src="https://avatars1.githubusercontent.com/u/1894628?v=3" width="100px;"/><br /><sub>Brad Bohen</sub>](https://github.com/bbohen)<br />[🐛](https://github.com/babel-utils/babel-plugin-tester/issues?q=author%3Abbohen "Bug reports") | [<img src="https://avatars0.githubusercontent.com/u/1295580?v=3" width="100px;"/><br /><sub>Kyle Welch</sub>](http://www.krwelch.com)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Documentation") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Tests") |
+| :---: | :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
       "kentcdodds/prettier"
     ],
     "rules": {
-      "func-style": "off"
+      "func-style": "off",
+      "max-lines": ["error", 1000]
     }
   },
   "lint-staged": {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -320,6 +320,57 @@ test('can provide a test filename for code strings', () => {
   )
 })
 
+test('can provide plugin options', () => {
+  const tests = [simpleTest]
+  const pluginOptions = {
+    optionA: true,
+  }
+  pluginTester(getOptions({tests, pluginOptions}))
+  expect(transformSpy).toHaveBeenCalledTimes(1)
+  expect(transformSpy).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.objectContaining({
+      plugins: expect.arrayContaining([
+        [
+          expect.any(Function),
+          expect.objectContaining({
+            optionA: true,
+          }),
+        ],
+      ]),
+    }),
+  )
+})
+
+test('can overwrite plugin options at test level', () => {
+  const pluginOptions = {
+    optionA: false,
+  }
+  const tests = [{code: simpleTest, pluginOptions}]
+  pluginTester(
+    getOptions({
+      tests,
+      pluginOptions: {
+        optionA: true,
+      },
+    }),
+  )
+  expect(transformSpy).toHaveBeenCalledTimes(1)
+  expect(transformSpy).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.objectContaining({
+      plugins: expect.arrayContaining([
+        [
+          expect.any(Function),
+          expect.objectContaining({
+            optionA: false,
+          }),
+        ],
+      ]),
+    }),
+  )
+})
+
 test('throws invariant if snapshot and output are both provided', () => {
   const tests = [{code: simpleTest, output: 'anything', snapshot: true}]
   expect(() =>

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ function pluginTester(
     plugin = requiredParam('plugin'),
     pluginName = getPluginName(plugin),
     title: describeBlockTitle = pluginName,
+    pluginOptions,
     tests,
     fixtures,
     filename,
@@ -33,6 +34,7 @@ function pluginTester(
     testFixtures({
       plugin,
       pluginName,
+      pluginOptions,
       title: describeBlockTitle,
       fixtures,
       filename,
@@ -62,7 +64,14 @@ function pluginTester(
       } = merge(
         {},
         testerConfig,
-        toTestConfig({testConfig, index, plugin, pluginName, filename}),
+        toTestConfig({
+          testConfig,
+          index,
+          plugin,
+          pluginName,
+          pluginOptions,
+          filename,
+        }),
       )
       assert(
         (!skip && !only) || skip !== only,
@@ -146,6 +155,7 @@ function pluginTester(
 
 function testFixtures({
   plugin,
+  pluginOptions,
   title: describeBlockTitle,
   fixtures,
   filename,
@@ -164,7 +174,7 @@ function testFixtures({
           fullDefaultConfig,
           {
             babelOptions: {
-              plugins: [plugin],
+              plugins: [[plugin, pluginOptions]],
               // if they have a babelrc, then we'll let them use that
               // otherwise, we'll just use our simple config
               babelrc: pathExists.sync(babelRcPath),
@@ -204,7 +214,14 @@ function toTestArray(tests) {
   }, [])
 }
 
-function toTestConfig({testConfig, index, plugin, pluginName, filename}) {
+function toTestConfig({
+  testConfig,
+  index,
+  plugin,
+  pluginName,
+  pluginOptions,
+  filename,
+}) {
   if (typeof testConfig === 'string') {
     testConfig = {code: testConfig}
   }
@@ -214,6 +231,7 @@ function toTestConfig({testConfig, index, plugin, pluginName, filename}) {
     code = getCode(filename, fixture),
     fullTitle = `${index + 1}. ${title || pluginName}`,
     output = getCode(filename, testConfig.outputFixture),
+    pluginOptions: testOptions = pluginOptions,
   } = testConfig
   return merge(
     {
@@ -221,7 +239,7 @@ function toTestConfig({testConfig, index, plugin, pluginName, filename}) {
     },
     testConfig,
     {
-      babelOptions: {plugins: [plugin]},
+      babelOptions: {plugins: [[plugin, testOptions]]},
       title: fullTitle,
       code: stripIndent(code).trim(),
       output: stripIndent(output).trim(),


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Provides the ability to pass plugin options at the tester and test level.

Also added associated tests and documentation. 

<!-- Why are these changes necessary? -->
**Why**:
I wanted to be able to test certain functionality not enabled by default

<!-- How were these changes implemented? -->
**How**:
- Added tests 😉 
- Added option to main start
- Updated test config to overwrite main option

<!-- feel free to add additional comments -->
