### PR TITLE
feat(formatResult): add `formatResult` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ If you set up some state, it's quite possible you want to tear it down. You can
 either define this as its own property, or you can return it from the `setup`
 function. This can likewise return a promise if it's asynchronous.
 
+#### formatResult
+
+This is a function and if it's specified, it allows you to format the result
+however you like. The use case for this originally was for testing codemods
+and formatting their result with `prettier-eslint`.
+
 ## Examples
 
 ### Full Example + Docs

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -514,6 +514,17 @@ test('error logged and thrown if teardown throws', async () => {
   )
 })
 
+test('allows formatting the result', async () => {
+  const formatResultSpy = jest.fn(r => r)
+  await pluginTester(
+    getOptions({
+      tests: [{code: simpleTest, formatResult: formatResultSpy}],
+    }),
+  )
+  expect(formatResultSpy).toHaveBeenCalledTimes(1)
+  expect(formatResultSpy).toHaveBeenCalledWith(simpleTest)
+})
+
 function getOptions(overrides) {
   return {
     pluginName: 'captains-log',

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ function pluginTester(
         error,
         setup = noop,
         teardown,
+        formatResult = r => r,
       } = merge(
         {},
         testerConfig,
@@ -141,7 +142,9 @@ function pluginTester(
         let errored = false
 
         try {
-          result = babel.transform(code, babelOptions).code.trim()
+          result = formatResult(
+            babel.transform(code, babelOptions).code.trim(),
+          )
         } catch (err) {
           if (error) {
             errored = true


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Adds a `formatResult` option

<!-- Why are these changes necessary? -->
**Why**: So people can format the snapshot with `prettier` or `prettier-eslint` if they want to.

<!-- How were these changes implemented? -->
**How**: apply `formatResult` function (defaults to an identity function) to the `result`.


<!-- feel free to add additional comments -->
