### PR TITLE
feat(test-numbers): only use numbers for tests without titles

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -109,7 +109,7 @@ test('calls describe and test for a group of tests', async () => {
   expect(itSpy.mock.calls).toEqual([
     [`1. ${pluginName}`, expect.any(Function)],
     [`2. ${pluginName}`, expect.any(Function)],
-    [`3. ${customTitle}`, expect.any(Function)],
+    [`${customTitle}`, expect.any(Function)],
   ])
 })
 
@@ -410,8 +410,8 @@ test('can provide an object for tests', async () => {
     [simpleTest, simpleTest, expect.any(String)],
   ])
   expect(itSpy.mock.calls).toEqual([
-    [`1. ${firstTitle}`, expect.any(Function)],
-    [`2. ${secondTitle}`, expect.any(Function)],
+    [firstTitle, expect.any(Function)],
+    [secondTitle, expect.any(Function)],
   ])
 })
 


### PR DESCRIPTION
This was super annoying. Any time I added/moved/removed a test, all the
snapshots would need updating because the title for every one of them
changed. Pretty annoying. So now we only use the number for untitled
tests and we only increment it for the untitled tests.

This is going to be a major version bump.