### PR TITLE
move babel-core to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "babel-core": "^6.25.0",
     "common-tags": "^1.4.0",
     "invariant": "^2.2.2",
     "lodash.merge": "^4.6.0",
@@ -29,12 +28,16 @@
     "strip-indent": "^2.0.0"
   },
   "devDependencies": {
+    "babel-core": "^6.25.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
     "babel-plugin-transform-async-generator-functions": "^6.24.1",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.5.2",
     "kcd-scripts": "^0.16.3"
+  },
+  "peerDependencies": {
+    "babel-core": "^6.0.0 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Make compatible with babel 7

<!-- Why are these changes necessary? -->
Currently, because babel-core is defined as a regular dependency - it prevents babel 7 usage. 

Also, please see: 
- https://github.com/facebook/jest/pull/4557/files
- https://github.com/babel/babel-bridge

<!-- How were these changes implemented? -->
Just a change to `package.json`
