### PR TITLE
feat: Create automatically fixtures output.js files for new tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "validate": "kcd-scripts validate",
     "precommit": "kcd-scripts precommit"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [],
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
@@ -45,7 +47,12 @@
       "max-lines": 0
     }
   },
-  "eslintIgnore": ["node_modules", "coverage", "dist", "fixtures"],
+  "eslintIgnore": [
+    "node_modules",
+    "coverage",
+    "dist",
+    "fixtures"
+  ],
   "babel": {
     "presets": [
       [
@@ -54,7 +61,9 @@
           "targets": {
             "node": "4.5"
           },
-          "exclude": ["transform-regenerator"]
+          "exclude": [
+            "transform-regenerator"
+          ]
         }
       ]
     ],

--- a/src/__tests__/fixtures/fixtures/without-output-file/code.js
+++ b/src/__tests__/fixtures/fixtures/without-output-file/code.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/src/index.js
+++ b/src/index.js
@@ -243,8 +243,15 @@ function testFixtures({
           .transformFileSync(codePath, babelOptions)
           .code.trim()
 
+        const outputPath = path.join(fixtureDir, `${fixtureOutputName}.js`)
+
+        if (!fs.existsSync(outputPath)) {
+          fs.writeFileSync(outputPath, actual)
+          return
+        }
+
         const output = fs
-          .readFileSync(path.join(fixtureDir, `${fixtureOutputName}.js`), 'utf8')
+          .readFileSync(outputPath, 'utf8')
           .trim()
 
         assert.equal(actual, output, 'actual output does not match output.js')


### PR DESCRIPTION
**Why**:
So fixtures mode works more like snapshots - if output is absent, just create it.