### PR TITLE
chore: Fixture failure message matching the output filename

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,11 @@ const createFixtureTests = (fixturesDir, options) => {
 
       const output = fs.readFileSync(outputPath, 'utf8').trim()
 
-      assert.equal(actual, output, 'actual output does not match output.js')
+      assert.equal(
+        actual,
+        output,
+        `actual output does not match ${fixtureOutputName}.js`,
+      )
     })
   })
 }


### PR DESCRIPTION
Followup to [this](https://github.com/babel-utils/babel-plugin-tester/pull/28#discussion_r194244833) - although I'm not sure if this is what you were talking about.