### PR TITLE
Add typescript file extension support

### DIFF
--- a/src/__tests__/fixtures/fixtures/typescript/code.ts
+++ b/src/__tests__/fixtures/fixtures/typescript/code.ts
@@ -1,0 +1,1 @@
+'use strict';

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -257,11 +257,12 @@ test('can pass tests in fixtures relative to the filename', async () => {
     }),
   )
   expect(describeSpy).toHaveBeenCalledTimes(2)
-  expect(itSpy).toHaveBeenCalledTimes(5)
+  expect(itSpy).toHaveBeenCalledTimes(6)
   expect(itSpy.mock.calls).toEqual([
     [`changed`, expect.any(Function)],
     [`nested a`, expect.any(Function)],
     [`nested b`, expect.any(Function)],
+    [`typescript`, expect.any(Function)],
     [`unchanged`, expect.any(Function)],
     [`without output file`, expect.any(Function)],
   ])
@@ -291,7 +292,7 @@ test('creates output file for new tests', async () => {
   )
 
   expect(writeFileSyncSpy.mock.calls[0]).toEqual([
-    expect.stringMatching(/\/output\.js$/),
+    expect.stringMatching(/\/output\.(j|t)s$/),
     "'use strict';",
   ])
 })

--- a/src/index.js
+++ b/src/index.js
@@ -209,16 +209,21 @@ function pluginTester({
 const createFixtureTests = (fixturesDir, options) => {
   fs.readdirSync(fixturesDir).forEach(caseName => {
     const fixtureDir = path.join(fixturesDir, caseName)
-    const codePath = path.join(fixtureDir, 'code.js')
+    const jsCodePath = path.join(fixtureDir, 'code.js')
+    const tsCodePath = path.join(fixtureDir, 'code.ts')
     const blockTitle = caseName.split('-').join(' ')
+    const codePath =
+      (pathExists.sync(jsCodePath) && jsCodePath) ||
+      (pathExists.sync(tsCodePath) && tsCodePath)
 
-    if (!pathExists.sync(codePath)) {
+    if (!codePath) {
       describe(blockTitle, () => {
         createFixtureTests(fixtureDir, options)
       })
       return
     }
 
+    const ext = /\.ts$/.test(codePath) ? '.ts' : '.js'
     it(blockTitle, () => {
       const {plugin, pluginOptions, fixtureOutputName, babel, ...rest} = options
 
@@ -239,7 +244,7 @@ const createFixtureTests = (fixturesDir, options) => {
       )
       const actual = babel.transformFileSync(codePath, babelOptions).code.trim()
 
-      const outputPath = path.join(fixtureDir, `${fixtureOutputName}.js`)
+      const outputPath = path.join(fixtureDir, `${fixtureOutputName}${ext}`)
 
       if (!fs.existsSync(outputPath)) {
         fs.writeFileSync(outputPath, actual)
@@ -251,7 +256,7 @@ const createFixtureTests = (fixturesDir, options) => {
       assert.equal(
         actual,
         output,
-        `actual output does not match ${fixtureOutputName}.js`,
+        `actual output does not match ${fixtureOutputName}${ext}`,
       )
     })
   })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Support typescript file extensions when running automated fixtures tests

<!-- Why are these changes necessary? -->
**Why**:
Made a babel plugin with typescript support and would like to run automated fixture tests on `.ts` files with this neat tester

<!-- How were these changes implemented? -->


<!-- feel free to add additional comments -->
