### PR TITLE
change babel-core import to optional require in default param

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import fs from 'fs'
 import pathExists from 'path-exists'
 import merge from 'lodash.merge'
 import invariant from 'invariant'
-import * as babelCore from 'babel-core'
 import stripIndent from 'strip-indent'
 import {oneLine} from 'common-tags'
 
@@ -22,7 +21,7 @@ const fullDefaultConfig = {
 
 function pluginTester({
   /* istanbul ignore next (TODO: write a test for this) */
-  babel = babelCore,
+  babel = require('babel-core'),
   plugin = requiredParam('plugin'),
   pluginName = getPluginName(plugin, babel),
   title: describeBlockTitle = pluginName,


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: babel-core was being imported in index.js so it can be used as a default parameter for pluginTester().  The result of this is that if a custom babel is passed into the function, babel-core will still be imported.  By moving the this functionality into a require() statement in the default parameter declaration we can stop index.js from requiring the module when it is not being used.  

<!-- Why are these changes necessary? -->
**Why**:  Since babel-core is a peer dependency, it won't be installed if a dependent project doesn't use it as a dependency.  This will cause errors in a project that uses a different or custom version of babel/core.  

For example:
```js
pluginTester = require('babel-plugin-tester');

pluginTester({
    babel: require('@babel/core'),
    ...
});
```
Causes the following error

```js
Error: Cannot find module 'babel-core'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/alexhogue/github/babel-plugin-tester-test/node_modules/babel-plugin-tester/dist/index.js:29:18)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
```


<!-- How were these changes implemented? -->
**How**:  The import statement was removed.  A require() statement was added (which the import would compile down to anyway).  This way, require('babel-core') will only be called if babel is not passed into pluginTester()


<!-- feel free to add additional comments -->
