### PR TITLE
Add documentation for working with babel.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ to provide this option.
 This can be used to pass options into your plugin at transform time. This option
 can be overwritten using the test object.
 
+##### babel.config.js
+
+To use [babel.config.js](https://babeljs.io/docs/en/configuration) instead of
+.babelrc, set babelOptions to the config object:
+
+```
+pluginTester({
+  plugin: yourPlugin,
+  ...
+  babelOptions: require('./babel.config.js'),
+  ...
+  tests: [
+    /* your test objects */
+  ],
+});
+
+```
+
 #### title
 
 This can be used to specify a title for the describe block (rather than using


### PR DESCRIPTION
Hi - I have been using babel-plugin-tester for a bit with my own plugins (LOVE IT!).  I discovered today that it already works with `babel.config.js`, but wanted to update the documentation for anyone else who runs into this problem.  The only changes are to README.md, no actual code changes.

Thanks!

PS I did not add myself to .all-contributorsrc because I haven't made any code changes, if you would prefer that I do this, please let me know.