### PR TITLE
Empty output

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -50,6 +50,16 @@
         "doc",
         "test"
       ]
+    },
+    {
+      "login": "kontrollanten",
+      "name": "kontrollanten",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/6680299?v=4",
+      "profile": "https://github.com/kontrollanten",
+      "contributions": [
+        "code"
+      ]
     }
-  ]
+  ],
+  "repoType": "github"
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [babel-plugin-tester](#babel-plugin-tester)
+  - [The problem](#the-problem)
+  - [This solution](#this-solution)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [import](#import)
+    - [Invoke](#invoke)
+    - [options](#options)
+    - [Test Objects](#test-objects)
+  - [Examples](#examples)
+    - [Full Example + Docs](#full-example--docs)
+    - [Simple Example](#simple-example)
+  - [Inspiration](#inspiration)
+  - [Other Solutions](#other-solutions)
+  - [Contributors](#contributors)
+  - [LICENSE](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # babel-plugin-tester
 
 Utilities for testing babel plugins
@@ -7,9 +29,9 @@ Utilities for testing babel plugins
 [![Dependencies][dependencyci-badge]][dependencyci]
 [![version][version-badge]][package]
 [![downloads][downloads-badge]][npm-stat]
-[![MIT License][license-badge]][LICENSE]
+[![MIT License][license-badge]][license]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -82,7 +104,10 @@ function identifierReversePlugin() {
     name: 'identifier reverse',
     visitor: {
       Identifier(idPath) {
-        idPath.node.name = idPath.node.name.split('').reverse().join('')
+        idPath.node.name = idPath.node.name
+          .split('')
+          .reverse()
+          .join('')
       },
     },
   }
@@ -428,7 +453,7 @@ pluginTester({
 
 I've been thinking about this for a while. The API was inspired by:
 
-- ESLint's [RuleTester][RuleTester]
+- ESLint's [RuleTester][ruletester]
 - [@thejameskyle][@thejameskyle]'s [tweet][jamestweet]
 
 ## Other Solutions
@@ -440,8 +465,10 @@ I've been thinking about this for a while. The API was inspired by:
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Tests") | [<img src="https://avatars3.githubusercontent.com/u/952783?v=3" width="100px;"/><br /><sub>james kyle</sub>](http://thejameskyle.com/)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Documentation") [👀](#review-thejameskyle "Reviewed Pull Requests") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Tests") | [<img src="https://avatars1.githubusercontent.com/u/1894628?v=3" width="100px;"/><br /><sub>Brad Bohen</sub>](https://github.com/bbohen)<br />[🐛](https://github.com/babel-utils/babel-plugin-tester/issues?q=author%3Abbohen "Bug reports") | [<img src="https://avatars0.githubusercontent.com/u/1295580?v=3" width="100px;"/><br /><sub>Kyle Welch</sub>](http://www.krwelch.com)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Documentation") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Tests") |
-| :---: | :---: | :---: | :---: |
+<!-- prettier-ignore -->
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Tests") | [<img src="https://avatars3.githubusercontent.com/u/952783?v=3" width="100px;"/><br /><sub><b>james kyle</b></sub>](http://thejameskyle.com/)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Documentation") [👀](#review-thejameskyle "Reviewed Pull Requests") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Tests") | [<img src="https://avatars1.githubusercontent.com/u/1894628?v=3" width="100px;"/><br /><sub><b>Brad Bohen</b></sub>](https://github.com/bbohen)<br />[🐛](https://github.com/babel-utils/babel-plugin-tester/issues?q=author%3Abbohen "Bug reports") | [<img src="https://avatars0.githubusercontent.com/u/1295580?v=3" width="100px;"/><br /><sub><b>Kyle Welch</b></sub>](http://www.krwelch.com)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Documentation") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Tests") | [<img src="https://avatars3.githubusercontent.com/u/6680299?v=4" width="100px;"/><br /><sub><b>kontrollanten</b></sub>](https://github.com/kontrollanten)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kontrollanten "Code") |
+| :---: | :---: | :---: | :---: | :---: |
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.
@@ -484,7 +511,7 @@ MIT
 [emojis]: https://github.com/kentcdodds/all-contributors#emoji-key
 [all-contributors]: https://github.com/kentcdodds/all-contributors
 [lodash.merge]: https://lodash.com/docs/4.17.4#merge
-[RuleTester]: http://eslint.org/docs/developer-guide/working-with-rules#rule-unit-tests
+[ruletester]: http://eslint.org/docs/developer-guide/working-with-rules#rule-unit-tests
 [@thejameskyle]: https://github.com/thejameskyle
 [jamestweet]: https://twitter.com/thejameskyle/status/864359438819262465
 [@babel/helper-plugin-test-runner]: https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-test-runner

--- a/README.md
+++ b/README.md
@@ -1,25 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-- [babel-plugin-tester](#babel-plugin-tester)
-  - [The problem](#the-problem)
-  - [This solution](#this-solution)
-  - [Installation](#installation)
-  - [Usage](#usage)
-    - [import](#import)
-    - [Invoke](#invoke)
-    - [options](#options)
-    - [Test Objects](#test-objects)
-  - [Examples](#examples)
-    - [Full Example + Docs](#full-example--docs)
-    - [Simple Example](#simple-example)
-  - [Inspiration](#inspiration)
-  - [Other Solutions](#other-solutions)
-  - [Contributors](#contributors)
-  - [LICENSE](#license)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # babel-plugin-tester
 
 Utilities for testing babel plugins
@@ -51,6 +29,26 @@ You're writing a babel plugin and want to write tests for it.
 This is a fairly simple abstraction to help you write tests for your babel
 plugin. It works with `jest` (my personal favorite) and most of it should also
 work with `mocha` and `jasmine`.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Installation](#installation)
+- [Usage](#usage)
+  - [import](#import)
+  - [Invoke](#invoke)
+  - [options](#options)
+  - [Test Objects](#test-objects)
+- [Examples](#examples)
+  - [Full Example + Docs](#full-example--docs)
+  - [Simple Example](#simple-example)
+- [Inspiration](#inspiration)
+- [Other Solutions](#other-solutions)
+- [Contributors](#contributors)
+- [LICENSE](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.5.2",
-    "kcd-scripts": "^0.16.3"
+    "kcd-scripts": "^0.42.1"
   },
   "peerDependencies": {
     "babel-core": "^6.0.0 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0"
@@ -44,6 +44,7 @@
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",
     "rules": {
+      "jest/valid-describe": 0,
       "max-lines": 0,
       "semi": [
         2,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,11 @@
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",
     "rules": {
-      "max-lines": 0
+      "max-lines": 0,
+      "semi": [
+        2,
+        "never"
+      ]
     }
   },
   "eslintIgnore": [

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -1,6 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. captains-log 1`] = `
+exports[`can fail tests in fixtures at an absolute path 1`] = `"actual output does not match output.js"`;
+
+exports[`default will throw if output changes 1`] = `"Expected output to not change, but it did"`;
+
+exports[`plugin is required 1`] = `"plugin is a required parameter."`;
+
+exports[`snapshot option can be derived from the root config 1`] = `"\`output\` cannot be provided with \`snapshot: true\`"`;
+
+exports[`takes a snapshot: 1. captains-log 1`] = `
 "
 var hi = \\"hey\\";
 
@@ -9,14 +17,6 @@ var hi = \\"hey\\";
 var ih = \\"hey\\";
 "
 `;
-
-exports[`can fail tests in fixtures at an absolute path 1`] = `"actual output does not match output.js"`;
-
-exports[`default will throw if output changes 1`] = `"Expected output to not change, but it did"`;
-
-exports[`plugin is required 1`] = `"plugin is a required parameter."`;
-
-exports[`snapshot option can be derived from the root config 1`] = `"\`output\` cannot be provided with \`snapshot: true\`"`;
 
 exports[`tests cannot be both only-ed and skipped 1`] = `"Cannot enable both skip and only on a test"`;
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -189,6 +189,36 @@ test('trims and deindents code and output', async () => {
   )
 })
 
+test('accepts an empty output', async () => {
+  const tests = [
+    {
+      code: `var eraseMe = 'junk'`,
+      output: '',
+    },
+  ]
+  let errorResponse
+  try {
+    await pluginTester(
+      getOptions({
+        plugin: () => ({
+          name: 'cleanup',
+          visitor: {
+            VariableDeclaration(p) {
+              p.remove()
+            },
+          },
+        }),
+        tests,
+      }),
+    )
+    errorResponse = false
+  } catch (error) {
+    errorResponse = true
+  }
+
+  expect(errorResponse).toEqual(false)
+})
+
 test('can get a code and output fixture that is an absolute path', async () => {
   const tests = [
     {

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const fullDefaultConfig = {
   },
 }
 
+// eslint-disable-next-line max-lines-per-function
 function pluginTester({
   /* istanbul ignore next (TODO: write a test for this) */
   babel = require('babel-core'),

--- a/src/index.js
+++ b/src/index.js
@@ -163,7 +163,7 @@ function pluginTester({
           expect(`\n${formattedOutput}\n`).toMatchSnapshot(title)
         } else if (error) {
           assertError(result, error)
-        } else if (output) {
+        } else if (typeof output === 'string') {
           assert.equal(result, output, 'Output is incorrect.')
         } else {
           assert.equal(
@@ -187,7 +187,7 @@ function pluginTester({
       fixture,
       code = getCode(filename, fixture),
       fullTitle = title || `${testNumber++}. ${pluginName}`,
-      output = getCode(filename, testConfig.outputFixture),
+      output = getCode(filename, testConfig.outputFixture) || undefined,
       pluginOptions: testOptions = pluginOptions,
     } = testConfig
     return merge(
@@ -199,7 +199,7 @@ function pluginTester({
         babelOptions: {plugins: [[plugin, testOptions]]},
         title: fullTitle,
         code: stripIndent(code).trim(),
-        output: stripIndent(output).trim(),
+        ...(output ? {output: stripIndent(output).trim()} : {}),
       },
     )
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Allowing expected `output` to be an empty string.

<!-- Why are these changes necessary? -->
**Why**:
There's cases when we just want to verify that a node gets removed.

<!-- How were these changes implemented? -->
**How**:
By removing the default behaviour of keeping `output` to be an empty string, and instead make it `undefined` if it isn't provided.

<!-- feel free to add additional comments -->
Bonus commits:
* Added a eslint rule to deny trailing semi colons.
* Upgraded kcd-scripts to make `npm run add-contributor` to work.