### PR TITLE
Fix failing tests upon upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "kcd-scripts test",
     "test:update": "npm test -- --updateSnapshot --coverage",
     "validate": "kcd-scripts validate",
-    "precommit": "kcd-scripts precommit"
+    "precommit": "kcd-scripts pre-commit"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -30,26 +30,27 @@
     "strip-indent": "^2.0.0"
   },
   "devDependencies": {
-    "babel-core": "^6.25.0",
-    "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-    "babel-plugin-transform-async-generator-functions": "^6.24.1",
-    "babel-plugin-transform-async-to-generator": "^6.24.1",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.5.2",
-    "kcd-scripts": "^0.42.1"
+    "@babel/core": "^7.2.0",
+    "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+    "@babel/plugin-transform-async-to-generator": "^7.2.0",
+    "@babel/preset-env": "^7.2.0",
+    "kcd-scripts": "^0.49.0"
   },
   "peerDependencies": {
-    "babel-core": "^6.0.0 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0"
+    "@babel/core": "^7.0.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",
     "rules": {
-      "jest/valid-describe": 0,
       "max-lines": 0,
-      "semi": [
-        2,
-        "never"
-      ]
+      "max-lines-per-function": 0,
+      "prefer-object-spread": 0,
+      "no-useless-catch": 0,
+      "babel/camelcase": 0,
+      "babel/valid-typeof": 0,
+      "babel/no-unused-expressions": 0,
+      "babel/quotes": 0,
+      "jest/prefer-todo": 0
     }
   },
   "eslintIgnore": [
@@ -61,7 +62,7 @@
   "babel": {
     "presets": [
       [
-        "env",
+        "@babel/preset-env",
         {
           "targets": {
             "node": "4.5"
@@ -73,11 +74,17 @@
       ]
     ],
     "plugins": [
-      "babel-plugin-syntax-trailing-function-commas",
-      "transform-async-to-generator",
-      "transform-async-generator-functions",
-      "transform-object-rest-spread"
+      "@babel/plugin-transform-async-to-generator",
+      "@babel/plugin-proposal-async-generator-functions",
+      "@babel/plugin-proposal-object-rest-spread"
     ]
+  },
+  "prettier": {
+    "printWidth": 80,
+    "bracketSpacing": false,
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "all"
   },
   "repository": {
     "type": "git",

--- a/src/__mocks__/@babel/core.js
+++ b/src/__mocks__/@babel/core.js
@@ -1,0 +1,3 @@
+import * as babel from '@babel/core'
+
+module.exports = {...babel}

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`1. captains-log 1`] = `
+"
+var hi = \\"hey\\";
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var ih = \\"hey\\";
+"
+`;
+
 exports[`can fail tests in fixtures at an absolute path 1`] = `"actual output does not match output.js"`;
 
 exports[`default will throw if output changes 1`] = `"Expected output to not change, but it did"`;
@@ -28,7 +38,7 @@ exports[`throws error if fixture provided and code changes 1`] = `"Expected outp
 
 exports[`throws error when error expected but no error thrown 1`] = `"Expected to throw error, but it did not."`;
 
-exports[`throws error when function doesn't return true 1`] = `"test message"`;
+exports[`throws error when function doesn't return true 1`] = `"[BABEL] unknown: test message (While processing: \\"base$0\\")"`;
 
 exports[`throws if output is incorrect 1`] = `"Output is incorrect."`;
 

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -1,15 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. captains-log 1`] = `
-"
-var hi = \\"hey\\";
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-var ih = \\"hey\\";
-"
-`;
-
 exports[`can fail tests in fixtures at an absolute path 1`] = `"actual output does not match output.js"`;
 
 exports[`default will throw if output changes 1`] = `"Expected output to not change, but it did"`;

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -495,7 +495,7 @@ test(`throws error when function doesn't return true`, () =>
 
 test('throws error when error expected but no error thrown', () =>
   snapshotPluginError(true, {
-    plugin: () => null,
+    plugin: () => ({}),
   }))
 
 test('throws error if there is a problem parsing', async () => {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,10 +1,11 @@
 import fs from 'fs'
 import path from 'path'
 import assert from 'assert'
-import * as babel from 'babel-core'
 // eslint-disable-next-line import/default
 import pluginTester from '../'
 import identifierReversePlugin from './helpers/identifier-reverse-plugin'
+
+const babel = require('@babel/core')
 
 let errorSpy,
   describeSpy,
@@ -510,7 +511,7 @@ test('throws error if there is a problem parsing', async () => {
     error = e
   }
   expect(error.constructor).toBe(SyntaxError)
-  expect(error.message.endsWith('Unexpected token (1:0)')).toBe(true)
+  expect(error.message).toContain('Unexpected token (1:0)')
 })
 
 test(`throws an error if babelrc is true with no filename`, () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable jest/valid-describe */
+
 import assert from 'assert'
 import path from 'path'
 import fs from 'fs'
@@ -19,10 +21,9 @@ const fullDefaultConfig = {
   },
 }
 
-// eslint-disable-next-line max-lines-per-function
 function pluginTester({
   /* istanbul ignore next (TODO: write a test for this) */
-  babel = require('babel-core'),
+  babel = require('@babel/core'),
   plugin = requiredParam('plugin'),
   pluginName = getPluginName(plugin, babel),
   title: describeBlockTitle = pluginName,

--- a/src/index.js
+++ b/src/index.js
@@ -317,7 +317,7 @@ function assertError(result, error) {
       throw result
     }
   } else if (typeof error === 'string') {
-    assert.equal(result.message, error, 'Error message is incorrect')
+    assert(result.message.includes(error), 'Error message is incorrect')
   } else if (error instanceof RegExp) {
     assert(
       error.test(result.message),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Babel packages, kcd-scripts also, have all been upgraded. Failing tests have been fixed

<!-- Why are these changes necessary? -->
**Why**:

`babel-plugin-helper` wasn't working with babel 7 without babel bridge.

<!-- How were these changes implemented? -->
**How**:

I've first upgraded dependencies. And then tried to fix errors that were caused due to babel 6 and 7 incompatibilities.