### PR TITLE
Avoid returning values in describe blocks

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -59,6 +59,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "rubennorte",
+      "name": "Rubén Norte",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/117921?v=4",
+      "profile": "https://github.com/rubennorte",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "repoType": "github"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Utilities for testing babel plugins
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][license]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -48,7 +48,6 @@ work with `mocha` and `jasmine`.
 - [LICENSE](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 
 ## Installation
 
@@ -464,8 +463,8 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Tests") | [<img src="https://avatars3.githubusercontent.com/u/952783?v=3" width="100px;"/><br /><sub><b>james kyle</b></sub>](http://thejameskyle.com/)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Documentation") [👀](#review-thejameskyle "Reviewed Pull Requests") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Tests") | [<img src="https://avatars1.githubusercontent.com/u/1894628?v=3" width="100px;"/><br /><sub><b>Brad Bohen</b></sub>](https://github.com/bbohen)<br />[🐛](https://github.com/babel-utils/babel-plugin-tester/issues?q=author%3Abbohen "Bug reports") | [<img src="https://avatars0.githubusercontent.com/u/1295580?v=3" width="100px;"/><br /><sub><b>Kyle Welch</b></sub>](http://www.krwelch.com)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Documentation") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Tests") | [<img src="https://avatars3.githubusercontent.com/u/6680299?v=4" width="100px;"/><br /><sub><b>kontrollanten</b></sub>](https://github.com/kontrollanten)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kontrollanten "Code") |
-| :---: | :---: | :---: | :---: | :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Tests") | [<img src="https://avatars3.githubusercontent.com/u/952783?v=3" width="100px;" alt="james kyle"/><br /><sub><b>james kyle</b></sub>](http://thejameskyle.com/)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Documentation") [👀](#review-thejameskyle "Reviewed Pull Requests") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Tests") | [<img src="https://avatars1.githubusercontent.com/u/1894628?v=3" width="100px;" alt="Brad Bohen"/><br /><sub><b>Brad Bohen</b></sub>](https://github.com/bbohen)<br />[🐛](https://github.com/babel-utils/babel-plugin-tester/issues?q=author%3Abbohen "Bug reports") | [<img src="https://avatars0.githubusercontent.com/u/1295580?v=3" width="100px;" alt="Kyle Welch"/><br /><sub><b>Kyle Welch</b></sub>](http://www.krwelch.com)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Documentation") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Tests") | [<img src="https://avatars3.githubusercontent.com/u/6680299?v=4" width="100px;" alt="kontrollanten"/><br /><sub><b>kontrollanten</b></sub>](https://github.com/kontrollanten)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kontrollanten "Code") | [<img src="https://avatars3.githubusercontent.com/u/117921?v=4" width="100px;" alt="Rubén Norte"/><br /><sub><b>Rubén Norte</b></sub>](https://github.com/rubennorte)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=rubennorte "Code") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=rubennorte "Tests") |
+| :---: | :---: | :---: | :---: | :---: | :---: |
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/src/index.js
+++ b/src/index.js
@@ -50,15 +50,16 @@ function pluginTester({
   }
   const testAsArray = toTestArray(tests)
   if (!testAsArray.length) {
-    return Promise.resolve()
+    return
   }
   const testerConfig = merge({}, fullDefaultConfig, rest)
 
-  return describe(describeBlockTitle, () => {
-    const promises = testAsArray.map(testConfig => {
+  describe(describeBlockTitle, () => {
+    testAsArray.forEach(testConfig => {
       if (!testConfig) {
-        return Promise.resolve()
+        return
       }
+
       const {
         skip,
         only,
@@ -79,12 +80,12 @@ function pluginTester({
 
       if (skip) {
         // eslint-disable-next-line jest/no-disabled-tests
-        return it.skip(title, testerWrapper)
+        it.skip(title, testerWrapper)
       } else if (only) {
         // eslint-disable-next-line jest/no-focused-tests
-        return it.only(title, testerWrapper)
+        it.only(title, testerWrapper)
       } else {
-        return it(title, testerWrapper)
+        it(title, testerWrapper)
       }
 
       async function testerWrapper() {
@@ -176,8 +177,6 @@ function pluginTester({
         }
       }
     })
-
-    return Promise.all(promises)
   })
 
   function toTestConfig(testConfig) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: This modifies the `describe` blocks generated by the tester to avoid returning promises.

<!-- Why are these changes necessary? -->
**Why**: Even though this use case is "correct", using `async` functions in `describe` blocks (or returning promises, in general) is a common programmer error as Jest doesn't allow tests to be defined asychronously. Jest >=24.3.0 starts warning against this (https://github.com/facebook/jest/pull/7852) and it will be an error in Jest 25. This makes the necessary changes to avoid the warning and a possible future error, while maintaining the same external API

<!-- How were these changes implemented? -->
**How**: I removed the return values for the `describe` blocks and updated all tests to mimic how Jest collects tests to wait for them to finish (instead of awaiting the promise we were returning previously).


<!-- feel free to add additional comments -->

Disclaimer: I'm a Jest core maintainer.