### PR TITLE
fix(fixtures): get options from root options.json

### DIFF
--- a/src/__tests__/fixtures/fixtures/options.json
+++ b/src/__tests__/fixtures/fixtures/options.json
@@ -1,0 +1,1 @@
+{"rootFoo": "rootBar"}

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -304,7 +304,7 @@ test('can pass tests in fixtures relative to the filename', async () => {
       tests: null,
     }),
   )
-  expect(describeSpy).toHaveBeenCalledTimes(4)
+  expect(describeSpy).toHaveBeenCalledTimes(5)
   expect(itSpy).toHaveBeenCalledTimes(8)
   expect(itSpy.mock.calls).toEqual([
     [`changed`, expect.any(Function)],
@@ -617,12 +617,16 @@ test('allows formatting fixtures results', async () => {
 })
 
 test('gets options from options.json files when using fixtures', async () => {
+  const optionRootFoo = jest.fn()
   const optionFoo = jest.fn()
   const optionBar = jest.fn()
   const pluginWithOptions = jest.fn(() => {
     return {
       visitor: {
         Program(programPath, state) {
+          if (state.opts.rootFoo === 'rootBar') {
+            optionRootFoo()
+          }
           if (state.opts.foo === 'bar') {
             optionFoo()
           }
@@ -641,6 +645,7 @@ test('gets options from options.json files when using fixtures', async () => {
     }),
   )
 
+  expect(optionRootFoo).toHaveBeenCalledTimes(8)
   expect(optionFoo).toHaveBeenCalledTimes(2)
   expect(optionBar).toHaveBeenCalledTimes(1)
 })

--- a/src/index.js
+++ b/src/index.js
@@ -209,6 +209,12 @@ function pluginTester({
 const createFixtureTests = (fixturesDir, options) => {
   if (!fs.statSync(fixturesDir).isDirectory()) return
 
+  const rootOptionsPath = path.join(fixturesDir, 'options.json')
+  let rootFixtureOptions = {}
+  if (pathExists.sync(rootOptionsPath)) {
+    rootFixtureOptions = require(rootOptionsPath)
+  }
+
   fs.readdirSync(fixturesDir).forEach(caseName => {
     const fixtureDir = path.join(fixturesDir, caseName)
     const optionsPath = path.join(fixtureDir, 'options.json')
@@ -228,7 +234,11 @@ const createFixtureTests = (fixturesDir, options) => {
       describe(blockTitle, () => {
         createFixtureTests(fixtureDir, {
           ...options,
-          pluginOptions: {...options.pluginOptions, ...fixturePluginOptions},
+          pluginOptions: {
+            ...rootFixtureOptions,
+            ...options.pluginOptions,
+            ...fixturePluginOptions,
+          },
         })
       })
       return
@@ -252,7 +262,16 @@ const createFixtureTests = (fixturesDir, options) => {
         fullDefaultConfig,
         {
           babelOptions: {
-            plugins: [[plugin, {...pluginOptions, ...fixturePluginOptions}]],
+            plugins: [
+              [
+                plugin,
+                {
+                  ...rootFixtureOptions,
+                  ...pluginOptions,
+                  ...fixturePluginOptions,
+                },
+              ],
+            ],
             // if they have a babelrc, then we'll let them use that
             // otherwise, we'll just use our simple config
             babelrc: pathExists.sync(babelRcPath),


### PR DESCRIPTION
**What**: Fixing options from root `options.json` not getting loaded

**Why**: The options should be loaded when specified in the root fixtures directory, currently they are not.

**How**: Checks if the current `fixturesDir` contains a `options.json` file and adds it to the plugin options.