### PR TITLE
fix: concat arrays in `babelOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ pluginTester({
   // only necessary if you use fixture or outputFixture in your tests
   filename: __filename,
 
-  // these will be `lodash.merge`d with the test objects
+  // these will be `lodash.mergeWith`d with the test objects
   // below are the defaults:
   babelOptions: {
     parserOpts: {},
@@ -469,6 +469,7 @@ Thanks goes to these people ([emoji key][emojis]):
 | [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=kentcdodds "Tests") | [<img src="https://avatars3.githubusercontent.com/u/952783?v=3" width="100px;" alt="james kyle"/><br /><sub><b>james kyle</b></sub>](http://thejameskyle.com/)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Documentation") [👀](#review-thejameskyle "Reviewed Pull Requests") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=thejameskyle "Tests") | [<img src="https://avatars1.githubusercontent.com/u/1894628?v=3" width="100px;" alt="Brad Bohen"/><br /><sub><b>Brad Bohen</b></sub>](https://github.com/bbohen)<br />[🐛](https://github.com/babel-utils/babel-plugin-tester/issues?q=author%3Abbohen "Bug reports") | [<img src="https://avatars0.githubusercontent.com/u/1295580?v=3" width="100px;" alt="Kyle Welch"/><br /><sub><b>Kyle Welch</b></sub>](http://www.krwelch.com)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Code") [📖](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Documentation") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=kwelch "Tests") | [<img src="https://avatars3.githubusercontent.com/u/6680299?v=4" width="100px;" alt="kontrollanten"/><br /><sub><b>kontrollanten</b></sub>](https://github.com/kontrollanten)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=kontrollanten "Code") | [<img src="https://avatars3.githubusercontent.com/u/117921?v=4" width="100px;" alt="Rubén Norte"/><br /><sub><b>Rubén Norte</b></sub>](https://github.com/rubennorte)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=rubennorte "Code") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=rubennorte "Tests") | [<img src="https://avatars2.githubusercontent.com/u/3869532?v=4" width="100px;" alt="André Neves"/><br /><sub><b>André Neves</b></sub>](http://andreneves.work)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=andrefgneves "Code") [⚠️](https://github.com/babel-utils/babel-plugin-tester/commits?author=andrefgneves "Tests") |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | [<img src="https://avatars0.githubusercontent.com/u/3842800?v=4" width="100px;" alt="Kristoffer K."/><br /><sub><b>Kristoffer K.</b></sub>](https://github.com/merceyz)<br />[💻](https://github.com/babel-utils/babel-plugin-tester/commits?author=merceyz "Code") |
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.
@@ -510,7 +511,7 @@ MIT
 [twitter-badge]: https://img.shields.io/twitter/url/https/github.com/babel-utils/babel-plugin-tester.svg?style=social
 [emojis]: https://github.com/kentcdodds/all-contributors#emoji-key
 [all-contributors]: https://github.com/kentcdodds/all-contributors
-[lodash.merge]: https://lodash.com/docs/4.17.4#merge
+[lodash.mergewith]: https://lodash.com/docs/4.17.4#mergeWith
 [ruletester]: http://eslint.org/docs/developer-guide/working-with-rules#rule-unit-tests
 [@thejameskyle]: https://github.com/thejameskyle
 [jamestweet]: https://twitter.com/thejameskyle/status/864359438819262465

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "common-tags": "^1.4.0",
     "invariant": "^2.2.2",
-    "lodash.merge": "^4.6.0",
+    "lodash.mergewith": "^4.6.0",
     "path-exists": "^3.0.0",
     "strip-indent": "^2.0.0"
   },

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -650,6 +650,52 @@ test('gets options from options.json files when using fixtures', async () => {
   expect(optionBar).toHaveBeenCalledTimes(1)
 })
 
+test('appends to root plugins array', async () => {
+  const optionRootFoo = jest.fn()
+  const optionFoo = jest.fn()
+  const optionBar = jest.fn()
+  const pluginWithOptions = jest.fn(() => {
+    return {
+      visitor: {
+        Program(programPath, state) {
+          if (state.opts.rootFoo === 'rootBar') {
+            optionRootFoo()
+          }
+          if (state.opts.foo === 'bar') {
+            optionFoo()
+          }
+          if (state.opts.bar === 'baz') {
+            optionBar()
+          }
+        },
+      },
+    }
+  })
+  const programVisitor = jest.fn()
+  const otherPlugin = () => {
+    return {
+      visitor: {
+        Program: programVisitor,
+      },
+    }
+  }
+
+  await runPluginTester(
+    getOptions({
+      plugin: pluginWithOptions,
+      fixtures: getFixturePath('fixtures'),
+      babelOptions: {
+        plugins: [otherPlugin],
+      },
+    }),
+  )
+
+  expect(optionRootFoo).toHaveBeenCalledTimes(8)
+  expect(optionFoo).toHaveBeenCalledTimes(2)
+  expect(optionBar).toHaveBeenCalledTimes(1)
+  expect(programVisitor).toHaveBeenCalledTimes(9)
+})
+
 function getOptions(overrides) {
   return {
     pluginName: 'captains-log',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: `babelOptions.plugins` cannot be used together with fixture tests, as the plugin config gets overridden.

<!-- Why are these changes necessary? -->
**Why**: To allow setups like:

```js
pluginTester({
  plugin: myPlugin,
  fixtures: join(__dirname, '__fixtures__'),
  babelOptions: {
    plugins: ['@babel/plugin-syntax-class-properties']
  }
});
```

```js
// __fixtures__/example/options.json
{
  "foo": "bar"
}
```

<!-- How were these changes implemented? -->
**How**: Replaced `lodash.merge` with [`lodash.mergeWith`](https://lodash.com/docs/4.17.11#mergeWith) with the following `customizer`:

```js
function mergeCustomizer(objValue, srcValue) {
  if (Array.isArray(objValue)) {
    return objValue.concat(srcValue)
  }
  return undefined
}
```


<!-- feel free to add additional comments -->

I found the test setup a bit confusing, but I hope that I added a good test scenario.