### PR TITLE
fix: trim input and output correctly

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -616,6 +616,18 @@ test('allows formatting fixtures results', async () => {
   expect(formatResultSpy).toHaveBeenCalledTimes(9)
 })
 
+test('works with a formatter adding a empty line', async () => {
+  // Simulate prettier adding an empty line at the end
+  const formatResultSpy = jest.fn(r => `${r.trim()}\n\n`)
+  await runPluginTester(
+    getOptions({
+      fixtures: getFixturePath('fixtures'),
+      formatResult: formatResultSpy,
+    }),
+  )
+  expect(formatResultSpy).toHaveBeenCalledTimes(9)
+})
+
 test('gets options from options.json files when using fixtures', async () => {
   const optionRootFoo = jest.fn()
   const optionFoo = jest.fn()

--- a/src/index.js
+++ b/src/index.js
@@ -137,7 +137,7 @@ function pluginTester({
         let errored = false
 
         try {
-          result = formatResult(babel.transform(code, babelOptions).code.trim())
+          result = formatResult(babel.transform(code, babelOptions).code)
         } catch (err) {
           if (error) {
             errored = true
@@ -170,8 +170,8 @@ function pluginTester({
           assert.equal(result, output, 'Output is incorrect.')
         } else {
           assert.equal(
-            result,
-            code,
+            result.trim(),
+            code.trim(),
             'Expected output to not change, but it did',
           )
         }
@@ -280,7 +280,7 @@ const createFixtureTests = (fixturesDir, options) => {
         rest,
       )
       const actual = formatResult(
-        babel.transformFileSync(codePath, babelOptions).code.trim(),
+        babel.transformFileSync(codePath, babelOptions).code,
       )
 
       const outputPath = path.join(fixtureDir, `${fixtureOutputName}${ext}`)
@@ -290,11 +290,11 @@ const createFixtureTests = (fixturesDir, options) => {
         return
       }
 
-      const output = fs.readFileSync(outputPath, 'utf8').trim()
+      const output = fs.readFileSync(outputPath, 'utf8')
 
       assert.equal(
-        actual,
-        output,
+        actual.trim(),
+        output.trim(),
         `actual output does not match ${fixtureOutputName}${ext}`,
       )
     })


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fixed `babel-plugin-tester` not trimming strings correctly

<!-- Why are these changes necessary? -->
**Why**:
When using a formatter that adds an empty line at the end of the string `babel-plugin-tester` will save the result with this empty line. In subsequent runs, when reading the output file it trims it off, causing the strings to not match.

<!-- How were these changes implemented? -->
**How**:
Call trim at assert.equal for both values and don't trim code passed to formatResult