### PR TITLE
Fix for line endings mismatch on Windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -348,7 +348,7 @@ const createFixtureTests = (fixturesDir, options) => {
 
       assert.equal(
         actual.trim(),
-        output.trim(),
+        fixLineEndings(output, endOfLine, output).trim(),
         `actual output does not match ${fixtureOutputName}${ext}`,
       )
     })


### PR DESCRIPTION
fixLineEndings should be applied to both actual and output files to be consistent. If one needs to check for line endings - he'll use 'preserve' any way.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
One-line fix: added fixLineEndings to 'output' before calling assert.equal

<!-- Why are these changes necessary? -->
Without it tests would behave differently on Windows and on Linux with default git settings (git will checkout as CRLF on windows but push with LF, so "green" tests on Linux will be red on Windows.

<!-- How were these changes implemented? -->
One line fix - see changes.
