### PR TITLE
Fix for line endings mismatch on Windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -187,7 +187,7 @@ function pluginTester({
         } else {
           assert.equal(
             result.trim(),
-            fixLineEndings(code+'', endOfLine, code).trim(),
+            fixLineEndings(code, endOfLine, code).trim(),
             'Expected output to not change, but it did',
           )
         }
@@ -348,7 +348,7 @@ const createFixtureTests = (fixturesDir, options) => {
 
       assert.equal(
         actual.trim(),
-        fixLineEndings(output+'', endOfLine, output).trim(),
+        fixLineEndings(output, endOfLine, output).trim(),
         `actual output does not match ${fixtureOutputName}${ext}`,
       )
     })

--- a/src/index.js
+++ b/src/index.js
@@ -187,7 +187,7 @@ function pluginTester({
         } else {
           assert.equal(
             result.trim(),
-            code.trim(),
+            fixLineEndings(code+'', endOfLine, code).trim(),
             'Expected output to not change, but it did',
           )
         }
@@ -348,7 +348,7 @@ const createFixtureTests = (fixturesDir, options) => {
 
       assert.equal(
         actual.trim(),
-        output.trim(),
+        fixLineEndings(output+'', endOfLine, output).trim(),
         `actual output does not match ${fixtureOutputName}${ext}`,
       )
     })


### PR DESCRIPTION
fixLineEndings should be applied to both actual and output files to be consistent. If one needs to check for line endings - he'll use 'preserve' any way.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
One-line fix: added fixLineEndings to 'output' before calling assert.equal

<!-- Why are these changes necessary? -->
Without it tests would behave differently on Windows and on Linux with default git settings (git will checkout as CRLF on windows but push with LF, so "green" tests on Linux will be red on Windows.

<!-- How were these changes implemented? -->
Just added fixLineEndings around expected value.
Two line fix - see changes.
