### PR TITLE
Feat: adds jsx support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "devDependencies": {
     "@babel/core": "^7.2.0",
     "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+    "@babel/plugin-syntax-jsx": "^7.2.0",
+    "@babel/plugin-syntax-typescript": "^7.3.3",
     "@babel/plugin-transform-async-to-generator": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
     "kcd-scripts": "^0.49.0"

--- a/src/__tests__/fixtures/fixtures/jsx-support/.babelrc
+++ b/src/__tests__/fixtures/fixtures/jsx-support/.babelrc
@@ -1,0 +1,5 @@
+{
+    "plugins": [
+        "@babel/plugin-syntax-jsx"
+    ]
+}

--- a/src/__tests__/fixtures/fixtures/jsx-support/code.jsx
+++ b/src/__tests__/fixtures/fixtures/jsx-support/code.jsx
@@ -1,0 +1,1 @@
+export default <div></div>;

--- a/src/__tests__/fixtures/fixtures/tsx-support/.babelrc
+++ b/src/__tests__/fixtures/fixtures/tsx-support/.babelrc
@@ -1,0 +1,5 @@
+{
+    "plugins": [
+        ["@babel/plugin-syntax-typescript", { "isTSX" : true }]
+    ]
+}

--- a/src/__tests__/fixtures/fixtures/tsx-support/code.tsx
+++ b/src/__tests__/fixtures/fixtures/tsx-support/code.tsx
@@ -1,0 +1,1 @@
+export default <div></div> as any;

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -306,11 +306,14 @@ test('can pass tests in fixtures relative to the filename', async () => {
     }),
   )
   expect(describeSpy).toHaveBeenCalledTimes(5)
-  expect(itSpy).toHaveBeenCalledTimes(8)
+  expect(itSpy).toHaveBeenCalledTimes(10)
+
   expect(itSpy.mock.calls).toEqual([
     [`changed`, expect.any(Function)],
+    [`jsx support`, expect.any(Function)],
     [`nested a`, expect.any(Function)],
     [`nested b`, expect.any(Function)],
+    [`tsx support`, expect.any(Function)],
     [`typescript`, expect.any(Function)],
     [`unchanged`, expect.any(Function)],
     [`nested with option`, expect.any(Function)],
@@ -342,10 +345,21 @@ test('creates output file for new tests', async () => {
     }),
   )
 
-  expect(writeFileSyncSpy.mock.calls[0]).toEqual([
-    expect.stringMatching(/(\/|\\)output\.(j|t)s$/),
-    "'use strict';",
-  ])
+  const calls = writeFileSyncSpy.mock.calls[0]
+  const outputMatch = /(\/|\\)output\.(j|t)sx?$/
+  if (calls[0].endsWith('.jsx')) {
+    expect(calls).toEqual([
+      expect.stringMatching(outputMatch),
+      'export default <div></div>;',
+    ])
+  } else if (calls[0].endsWith('.tsx')) {
+    expect(calls).toEqual([
+      expect.stringMatching(outputMatch),
+      'export default <div></div> as any;',
+    ])
+  } else {
+    expect(calls).toEqual([expect.stringMatching(outputMatch), "'use strict';"])
+  }
 })
 
 test('uses the fixture filename in babelOptions', async () => {
@@ -614,7 +628,7 @@ test('allows formatting fixtures results', async () => {
       formatResult: formatResultSpy,
     }),
   )
-  expect(formatResultSpy).toHaveBeenCalledTimes(9)
+  expect(formatResultSpy).toHaveBeenCalledTimes(11)
 })
 
 test('works with a formatter adding a empty line', async () => {
@@ -626,7 +640,7 @@ test('works with a formatter adding a empty line', async () => {
       formatResult: formatResultSpy,
     }),
   )
-  expect(formatResultSpy).toHaveBeenCalledTimes(9)
+  expect(formatResultSpy).toHaveBeenCalledTimes(11)
 })
 
 test('gets options from options.json files when using fixtures', async () => {
@@ -658,7 +672,7 @@ test('gets options from options.json files when using fixtures', async () => {
     }),
   )
 
-  expect(optionRootFoo).toHaveBeenCalledTimes(8)
+  expect(optionRootFoo).toHaveBeenCalledTimes(10)
   expect(optionFoo).toHaveBeenCalledTimes(2)
   expect(optionBar).toHaveBeenCalledTimes(1)
 })
@@ -703,10 +717,10 @@ test('appends to root plugins array', async () => {
     }),
   )
 
-  expect(optionRootFoo).toHaveBeenCalledTimes(8)
+  expect(optionRootFoo).toHaveBeenCalledTimes(10)
   expect(optionFoo).toHaveBeenCalledTimes(2)
   expect(optionBar).toHaveBeenCalledTimes(1)
-  expect(programVisitor).toHaveBeenCalledTimes(9)
+  expect(programVisitor).toHaveBeenCalledTimes(11)
 })
 
 test('endOfLine - default', async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -265,11 +265,14 @@ const createFixtureTests = (fixturesDir, options) => {
     const optionsPath = path.join(fixtureDir, 'options.json')
     const jsCodePath = path.join(fixtureDir, 'code.js')
     const tsCodePath = path.join(fixtureDir, 'code.ts')
+    const jsxCodePath = path.join(fixtureDir, 'code.jsx')
+    const tsxCodePath = path.join(fixtureDir, 'code.tsx')
     const blockTitle = caseName.split('-').join(' ')
     const codePath =
       (pathExists.sync(jsCodePath) && jsCodePath) ||
-      (pathExists.sync(tsCodePath) && tsCodePath)
-
+      (pathExists.sync(tsCodePath) && tsCodePath) || 
+      (pathExists.sync(jsxCodePath) && jsxCodePath) ||
+      (pathExists.sync(tsxCodePath) && tsxCodePath)
     let fixturePluginOptions = {}
     if (pathExists.sync(optionsPath)) {
       fixturePluginOptions = require(optionsPath)
@@ -289,7 +292,7 @@ const createFixtureTests = (fixturesDir, options) => {
       return
     }
 
-    const ext = /\.ts$/.test(codePath) ? '.ts' : '.js'
+    const ext = `.${ codePath.split('.').pop() }`;
     it(blockTitle, () => {
       const {
         plugin,


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Added support for .jsx files in fixtures

<!-- Why are these changes necessary? -->
**Why**: Babel plugin can manage .jsx

<!-- How were these changes implemented? -->
**How**: Some code changes


<!-- feel free to add additional comments -->
