### PR TITLE
fix: remove unnecessary packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "common-tags": "^1.4.0",
     "invariant": "^2.2.2",
     "lodash.mergewith": "^4.6.0",
     "strip-indent": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "common-tags": "^1.4.0",
     "invariant": "^2.2.2",
     "lodash.mergewith": "^4.6.0",
-    "path-exists": "^4.0.0",
     "strip-indent": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "invariant": "^2.2.2",
     "lodash.mergewith": "^4.6.0",
     "strip-indent": "^3.0.0"
   },

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`assert throws if code is unchanged + snapshot enabled 1`] = `"Code was unmodified but attempted to take a snapshot. If the code should not be modified, set \`snapshot: false\`"`;
+
+exports[`assert throws if snapshot and output are both provided 1`] = `"\`output\` cannot be provided with \`snapshot: true\`"`;
+
+exports[`assert throws if the plugin name is not inferable 1`] = `"The \`pluginName\` must be inferable or provided."`;
+
+exports[`assert throws if there's no code 1`] = `"A string or object with a \`code\` or \`fixture\` property must be provided"`;
+
 exports[`can fail tests in fixtures at an absolute path 1`] = `"actual output does not match output.js"`;
 
 exports[`default will throw if output changes 1`] = `"Expected output to not change, but it did"`;
@@ -22,8 +30,6 @@ exports[`tests cannot be both only-ed and skipped 1`] = `"Cannot enable both ski
 
 exports[`throws an error if babelrc is true with no filename 1`] = `"babelrc set to true, but no filename specified in babelOptions"`;
 
-exports[`throws an invariant if the plugin name is not inferable 1`] = `"The \`pluginName\` must be inferable or provided."`;
-
 exports[`throws error if fixture provided and code changes 1`] = `"Expected output to not change, but it did"`;
 
 exports[`throws error when error expected but no error thrown 1`] = `"Expected to throw error, but it did not."`;
@@ -31,9 +37,3 @@ exports[`throws error when error expected but no error thrown 1`] = `"Expected t
 exports[`throws error when function doesn't return true 1`] = `"[BABEL] unknown: test message (While processing: \\"base$0\\")"`;
 
 exports[`throws if output is incorrect 1`] = `"Output is incorrect."`;
-
-exports[`throws invariant if code is unchanged + snapshot enabled 1`] = `"Code was unmodified but attempted to take a snapshot. If the code should not be modified, set \`snapshot: false\`"`;
-
-exports[`throws invariant if snapshot and output are both provided 1`] = `"\`output\` cannot be provided with \`snapshot: true\`"`;
-
-exports[`throws invariant if there's no code 1`] = `"A string or object with a \`code\` or \`fixture\` property must be provided"`;

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -84,7 +84,7 @@ test('logs when plugin name is not inferable and rethrows errors', async () => {
   )
 })
 
-test('throws an invariant if the plugin name is not inferable', async () => {
+test('assert throws if the plugin name is not inferable', async () => {
   await expect(
     runPluginTester({
       plugin: () => ({}),
@@ -184,7 +184,7 @@ test('throws if output is incorrect', async () => {
   await snapshotOptionsError(getOptions({tests}))
 })
 
-test(`throws invariant if there's no code`, async () => {
+test(`assert throws if there's no code`, async () => {
   const tests = [{}]
   await snapshotOptionsError(getOptions({tests}))
 })
@@ -463,7 +463,7 @@ test('can overwrite plugin options at test level', async () => {
   )
 })
 
-test('throws invariant if snapshot and output are both provided', async () => {
+test('assert throws if snapshot and output are both provided', async () => {
   const tests = [{code: simpleTest, output: 'anything', snapshot: true}]
   await snapshotOptionsError(getOptions({tests}))
 })
@@ -473,7 +473,7 @@ test('snapshot option can be derived from the root config', async () => {
   await snapshotOptionsError(getOptions({snapshot: true, tests}))
 })
 
-test('throws invariant if code is unchanged + snapshot enabled', async () => {
+test('assert throws if code is unchanged + snapshot enabled', async () => {
   const tests = [simpleTest]
   await snapshotOptionsError(getOptions({snapshot: true, tests}))
 })

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import {EOL} from 'os'
 import mergeWith from 'lodash.mergewith'
 import invariant from 'invariant'
 import stripIndent from 'strip-indent'
-import {oneLine} from 'common-tags'
 
 const noop = () => {}
 
@@ -136,10 +135,7 @@ function pluginTester({
       function tester() {
         invariant(
           code,
-          oneLine`
-            A string or object with a \`code\` or
-            \`fixture\` property must be provided
-          `,
+          'A string or object with a `code` or `fixture` property must be provided',
         )
         invariant(
           !babelOptions.babelrc || babelOptions.filename,
@@ -179,10 +175,7 @@ function pluginTester({
         if (snapshot) {
           invariant(
             result !== code,
-            oneLine`
-              Code was unmodified but attempted to take a snapshot.
-              If the code should not be modified, set \`snapshot: false\`
-            `,
+            'Code was unmodified but attempted to take a snapshot. If the code should not be modified, set `snapshot: false`',
           )
           const separator = '\n\n      ↓ ↓ ↓ ↓ ↓ ↓\n\n'
           const formattedOutput = [code, separator, result].join('')
@@ -444,10 +437,7 @@ function getPluginName(plugin, babel) {
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(
-      oneLine`
-        Attempting to infer the name of your plugin failed.
-        Tried to invoke the plugin which threw the error.
-      `,
+      'Attempting to infer the name of your plugin failed. Tried to invoke the plugin which threw the error.',
     )
     throw error
   }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import assert from 'assert'
 import path from 'path'
 import fs from 'fs'
 import {EOL} from 'os'
-import pathExists from 'path-exists'
 import mergeWith from 'lodash.mergewith'
 import invariant from 'invariant'
 import stripIndent from 'strip-indent'
@@ -264,7 +263,7 @@ const createFixtureTests = (fixturesDir, options) => {
 
   const rootOptionsPath = path.join(fixturesDir, 'options.json')
   let rootFixtureOptions = {}
-  if (pathExists.sync(rootOptionsPath)) {
+  if (fs.existsSync(rootOptionsPath)) {
     rootFixtureOptions = require(rootOptionsPath)
   }
 
@@ -277,12 +276,12 @@ const createFixtureTests = (fixturesDir, options) => {
     const tsxCodePath = path.join(fixtureDir, 'code.tsx')
     const blockTitle = caseName.split('-').join(' ')
     const codePath =
-      (pathExists.sync(jsCodePath) && jsCodePath) ||
-      (pathExists.sync(tsCodePath) && tsCodePath) ||
-      (pathExists.sync(jsxCodePath) && jsxCodePath) ||
-      (pathExists.sync(tsxCodePath) && tsxCodePath)
+      (fs.existsSync(jsCodePath) && jsCodePath) ||
+      (fs.existsSync(tsCodePath) && tsCodePath) ||
+      (fs.existsSync(jsxCodePath) && jsxCodePath) ||
+      (fs.existsSync(tsxCodePath) && tsxCodePath)
     let fixturePluginOptions = {}
-    if (pathExists.sync(optionsPath)) {
+    if (fs.existsSync(optionsPath)) {
       fixturePluginOptions = require(optionsPath)
     }
 
@@ -331,7 +330,7 @@ const createFixtureTests = (fixturesDir, options) => {
             ],
             // if they have a babelrc, then we'll let them use that
             // otherwise, we'll just use our simple config
-            babelrc: pathExists.sync(babelRcPath),
+            babelrc: fs.existsSync(babelRcPath),
           },
         },
         rest,

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import path from 'path'
 import fs from 'fs'
 import {EOL} from 'os'
 import mergeWith from 'lodash.mergewith'
-import invariant from 'invariant'
 import stripIndent from 'strip-indent'
 
 const noop = () => {}
@@ -133,15 +132,15 @@ function pluginTester({
 
       // eslint-disable-next-line complexity
       function tester() {
-        invariant(
+        assert(
           code,
           'A string or object with a `code` or `fixture` property must be provided',
         )
-        invariant(
+        assert(
           !babelOptions.babelrc || babelOptions.filename,
           'babelrc set to true, but no filename specified in babelOptions',
         )
-        invariant(
+        assert(
           !snapshot || !output,
           '`output` cannot be provided with `snapshot: true`',
         )
@@ -173,7 +172,7 @@ function pluginTester({
         )
 
         if (snapshot) {
-          invariant(
+          assert(
             result !== code,
             'Code was unmodified but attempted to take a snapshot. If the code should not be modified, set `snapshot: false`',
           )
@@ -419,7 +418,7 @@ function assertError(result, error) {
       `Expected ${result.message} to match ${error}`,
     )
   } else {
-    invariant(
+    assert(
       typeof error === 'boolean',
       'The given `error` must be a function, string, boolean, or RegExp',
     )
@@ -441,7 +440,7 @@ function getPluginName(plugin, babel) {
     )
     throw error
   }
-  invariant(name, 'The `pluginName` must be inferable or provided.')
+  assert(name, 'The `pluginName` must be inferable or provided.')
   return name
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -444,8 +444,14 @@ function getPluginName(plugin, babel) {
   return name
 }
 
+// unfortunately the ESLint plugin for Jest thinks this is a test file
+// a better solution might be to adjust the eslint config so it doesn't
+// but I don't have time to do that at the moment.
 /*
 eslint
   complexity: "off",
   jest/valid-describe: "off"
+  jest/no-export: "off"
+  jest/valid-title: "off"
+  jest/no-if: "off"
 */

--- a/src/index.js
+++ b/src/index.js
@@ -450,8 +450,8 @@ function getPluginName(plugin, babel) {
 /*
 eslint
   complexity: "off",
-  jest/valid-describe: "off"
-  jest/no-export: "off"
-  jest/valid-title: "off"
-  jest/no-if: "off"
+  jest/valid-describe: "off",
+  jest/no-export: "off",
+  jest/valid-title: "off",
+  jest/no-if: "off",
 */


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Removed unnecessary packages `path-exists`, `common-tags`, and `invariant`

<!-- Why are these changes necessary? -->

**Why**:
- `path-exists`: Node has `fs.existsSync` that does the same task, the package even advises using it instead
> NOTE: fs.existsSync has been un-deprecated in Node.js since 6.8.0. If you only need to check synchronously, this module is not needed.
https://github.com/sindresorhus/path-exists
- `common-tags`: Downloading a [5.6kB](https://bundlephobia.com/result?p=common-tags@1.8.0) package to make our errors single line is unnecessary
- `invariant`: Node has `assert` which does the same job and is used elsewhere in the code

<!-- How were these changes implemented? -->

**How**:
- `path-exists`: Replaced with `fs.existsSync`
- `common-tags`: Removed the linebreaks from the strings we were using `oneLine` on
- `invariant`: Replaced with `assert`

<!-- feel free to add additional comments -->
