### PR TITLE
fix: check for js and cjs version of babelrc

### DIFF
--- a/src/__tests__/fixtures/fixtures/babelrc/cjs/.babelrc.cjs
+++ b/src/__tests__/fixtures/fixtures/babelrc/cjs/.babelrc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [
+    require.resolve("@babel/plugin-syntax-jsx")
+  ]
+}

--- a/src/__tests__/fixtures/fixtures/babelrc/cjs/code.jsx
+++ b/src/__tests__/fixtures/fixtures/babelrc/cjs/code.jsx
@@ -1,0 +1,1 @@
+export default <div></div>;

--- a/src/__tests__/fixtures/fixtures/babelrc/js/.babelrc.js
+++ b/src/__tests__/fixtures/fixtures/babelrc/js/.babelrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [
+    require.resolve("@babel/plugin-syntax-jsx")
+  ]
+}

--- a/src/__tests__/fixtures/fixtures/babelrc/js/code.jsx
+++ b/src/__tests__/fixtures/fixtures/babelrc/js/code.jsx
@@ -1,0 +1,1 @@
+export default <div></div>;

--- a/src/__tests__/fixtures/fixtures/babelrc/normal/.babelrc
+++ b/src/__tests__/fixtures/fixtures/babelrc/normal/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "@babel/plugin-syntax-jsx"
+  ]
+}

--- a/src/__tests__/fixtures/fixtures/babelrc/normal/code.jsx
+++ b/src/__tests__/fixtures/fixtures/babelrc/normal/code.jsx
@@ -1,0 +1,1 @@
+export default <div></div>;

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -301,10 +301,13 @@ test('can pass tests in fixtures relative to the filename', async () => {
       tests: null,
     }),
   )
-  expect(describeSpy).toHaveBeenCalledTimes(5)
-  expect(itSpy).toHaveBeenCalledTimes(10)
+  expect(describeSpy).toHaveBeenCalledTimes(6)
+  expect(itSpy).toHaveBeenCalledTimes(13)
 
   expect(itSpy.mock.calls).toEqual([
+    [`cjs`, expect.any(Function)],
+    [`js`, expect.any(Function)],
+    [`normal`, expect.any(Function)],
     [`changed`, expect.any(Function)],
     [`jsx support`, expect.any(Function)],
     [`nested a`, expect.any(Function)],
@@ -612,7 +615,7 @@ test('allows formatting fixtures results', async () => {
       formatResult: formatResultSpy,
     }),
   )
-  expect(formatResultSpy).toHaveBeenCalledTimes(11)
+  expect(formatResultSpy).toHaveBeenCalledTimes(14)
 })
 
 test('works with a formatter adding a empty line', async () => {
@@ -624,7 +627,7 @@ test('works with a formatter adding a empty line', async () => {
       formatResult: formatResultSpy,
     }),
   )
-  expect(formatResultSpy).toHaveBeenCalledTimes(11)
+  expect(formatResultSpy).toHaveBeenCalledTimes(14)
 })
 
 test('gets options from options.json files when using fixtures', async () => {
@@ -656,7 +659,7 @@ test('gets options from options.json files when using fixtures', async () => {
     }),
   )
 
-  expect(optionRootFoo).toHaveBeenCalledTimes(10)
+  expect(optionRootFoo).toHaveBeenCalledTimes(13)
   expect(optionFoo).toHaveBeenCalledTimes(2)
   expect(optionBar).toHaveBeenCalledTimes(1)
 })
@@ -701,10 +704,10 @@ test('appends to root plugins array', async () => {
     }),
   )
 
-  expect(optionRootFoo).toHaveBeenCalledTimes(10)
+  expect(optionRootFoo).toHaveBeenCalledTimes(13)
   expect(optionFoo).toHaveBeenCalledTimes(2)
   expect(optionBar).toHaveBeenCalledTimes(1)
-  expect(programVisitor).toHaveBeenCalledTimes(11)
+  expect(programVisitor).toHaveBeenCalledTimes(14)
 })
 
 test('endOfLine - default', async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -303,7 +303,9 @@ const createFixtureTests = (fixturesDir, options) => {
         ...rest
       } = options
 
-      const babelRcPath = path.join(fixtureDir, '.babelrc')
+      const hasBabelrc = ['.babelrc', '.babelrc.js', '.babelrc.cjs'].some(
+        babelrc => fs.existsSync(path.join(fixtureDir, babelrc)),
+      )
 
       const {babelOptions} = mergeWith(
         {},
@@ -322,7 +324,7 @@ const createFixtureTests = (fixturesDir, options) => {
             ],
             // if they have a babelrc, then we'll let them use that
             // otherwise, we'll just use our simple config
-            babelrc: fs.existsSync(babelRcPath),
+            babelrc: hasBabelrc,
           },
         },
         rest,


### PR DESCRIPTION
**What**:
Check for `js` and `cjs` version of `.babelrc`

**Why**:
Babel supports `.babelrc.js` and `.babelrc.cjs`
> File-relative configuration
.babelrc (and .babelrc.js or .babelrc.cjs) files
https://babeljs.io/docs/en/config-files

**How**:
Extend the check for `.babelrc` to include `.babelrc.js` and `.babelrc.cjs`
