### PR TITLE
fix: Crash when importing without global expect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import prettierFormatter from './formatters/prettier'
 import unstringSnapshotSerializer from './unstring-snapshot-serializer'
 
 // istanbul ignore else (it's not worth testing)
-if (expect.addSnapshotSerializer) {
+if (typeof expect !== 'undefined' && expect.addSnapshotSerializer) {
   expect.addSnapshotSerializer(unstringSnapshotSerializer)
 }
 


### PR DESCRIPTION

**What**:

Don't add the snapshotSerializer if `expect` isn't defined

**Why**:

Crashes in non-jest environments (https://app.circleci.com/jobs/github/mui-org/material-ui/129232)

**How**:

Guard with `typeof expect`