### PR TITLE
added 'fixtureOutputExt' configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ Use this to provide your own implementation of babel. This is particularly
 useful if you want to use a different version of babel than what's included in
 this package.
 
+#### fixtureOutputExt
+
+Use this to provide your own fixture output file extension. This is particularly
+useful if you are testing typescript input. If ommited fixture input file extension
+will be used.
+
 #### ...rest
 
 The rest of the options you provide will be [`lodash.merge`][lodash.merge]d with

--- a/src/__tests__/fixtures/fixtures/fixtureOutputExt/code.ts
+++ b/src/__tests__/fixtures/fixtures/fixtureOutputExt/code.ts
@@ -1,0 +1,1 @@
+'use strict';

--- a/src/__tests__/fixtures/fixtures/fixtureOutputExt/options.json
+++ b/src/__tests__/fixtures/fixtures/fixtureOutputExt/options.json
@@ -1,0 +1,1 @@
+{"fixtureOutputExt": ".js"}

--- a/src/__tests__/fixtures/fixtures/fixtureOutputExt/output.js
+++ b/src/__tests__/fixtures/fixtures/fixtureOutputExt/output.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/src/__tests__/plugin-tester.js
+++ b/src/__tests__/plugin-tester.js
@@ -305,13 +305,14 @@ test('can pass tests in fixtures relative to the filename', async () => {
     }),
   )
   expect(describeSpy).toHaveBeenCalledTimes(6)
-  expect(itSpy).toHaveBeenCalledTimes(13)
+  expect(itSpy).toHaveBeenCalledTimes(14)
 
   expect(itSpy.mock.calls).toEqual([
     [`cjs`, expect.any(Function)],
     [`js`, expect.any(Function)],
     [`normal`, expect.any(Function)],
     [`changed`, expect.any(Function)],
+    [`fixtureOutputExt`, expect.any(Function)],
     [`jsx support`, expect.any(Function)],
     [`nested a`, expect.any(Function)],
     [`nested b`, expect.any(Function)],
@@ -620,7 +621,7 @@ test('allows formatting fixtures results', async () => {
       formatResult: formatResultSpy,
     }),
   )
-  expect(formatResultSpy).toHaveBeenCalledTimes(14)
+  expect(formatResultSpy).toHaveBeenCalledTimes(15)
 })
 
 test('works with a formatter adding a empty line', async () => {
@@ -632,7 +633,7 @@ test('works with a formatter adding a empty line', async () => {
       formatResult: formatResultSpy,
     }),
   )
-  expect(formatResultSpy).toHaveBeenCalledTimes(14)
+  expect(formatResultSpy).toHaveBeenCalledTimes(15)
 })
 
 test('prettier formatter supported', async () => {
@@ -682,7 +683,7 @@ test('gets options from options.json files when using fixtures', async () => {
     }),
   )
 
-  expect(optionRootFoo).toHaveBeenCalledTimes(13)
+  expect(optionRootFoo).toHaveBeenCalledTimes(14)
   expect(optionFoo).toHaveBeenCalledTimes(2)
   expect(optionBar).toHaveBeenCalledTimes(1)
 })
@@ -727,10 +728,10 @@ test('appends to root plugins array', async () => {
     }),
   )
 
-  expect(optionRootFoo).toHaveBeenCalledTimes(13)
+  expect(optionRootFoo).toHaveBeenCalledTimes(14)
   expect(optionFoo).toHaveBeenCalledTimes(2)
   expect(optionBar).toHaveBeenCalledTimes(1)
-  expect(programVisitor).toHaveBeenCalledTimes(14)
+  expect(programVisitor).toHaveBeenCalledTimes(15)
 })
 
 test('endOfLine - default', async () => {

--- a/src/plugin-tester.js
+++ b/src/plugin-tester.js
@@ -293,7 +293,6 @@ const createFixtureTests = (fixturesDir, options) => {
       return
     }
 
-    const ext = `.${codePath.split('.').pop()}`
     it(blockTitle, () => {
       const {
         plugin,
@@ -344,6 +343,14 @@ const createFixtureTests = (fixturesDir, options) => {
           input,
         ),
       )
+
+      const {fixtureOutputExt} = fixturePluginOptions
+      let ext
+      if (fixtureOutputExt) {
+        ext = fixtureOutputExt
+      } else {
+        ext = `.${codePath.split('.').pop()}`
+      }
 
       const outputPath = path.join(fixtureDir, `${fixtureOutputName}${ext}`)
 


### PR DESCRIPTION
details can be found in issue #72 

---

ps: i was forced to commit via `git commit -no-verify` because otherwise im getting this error:
```
c:\projects\github\babel-plugin-tester>git commit
husky > pre-commit (node v12.16.3)
sh: C:projectsgithubbabel-plugin-testernode_modules.binkcd-scripts.CMD: command not found
husky > pre-commit hook failed (add --no-verify to bypass)
```

(im guessing, that something is stripping `\` from path and also i dont have file
`C:\projects\github\babel-plugin-tester\node_modules\.binkcd-scripts.CMD` on my pc even after deleting node_modules and caling `npm install` again ... , also i have no idea what `husky` is ...)

OS: `windows 10 v 1909 build 18363.836`
npm -v: `6.14.4`
node -v: `v12.16.3`



