### PR TITLE
Add verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,10 @@ Learn more about the built-in formatter below.
 The use case for this originally was for testing codemods and formatting their
 result with `prettier-eslint`.
 
+## verbose
+
+By enabling this option, you can see the input and transformations output of your babel plugin's tests.
+
 ## Examples
 
 ### Full Example + Docs
@@ -381,6 +385,9 @@ pluginTester({
 
   // defaults to a function that formats with prettier
   formatResult: customFormatFunction,
+
+  // verbose transformations
+  verbose: false,
 
   // tests as objects
   tests: {

--- a/src/plugin-tester.js
+++ b/src/plugin-tester.js
@@ -169,7 +169,9 @@ function pluginTester({
         }
 
         if (verbose) {
+          // eslint-disable-next-line no-console
           console.log(testFilename)
+          // eslint-disable-next-line no-console
           console.log({code, output, result})
         }
 

--- a/src/plugin-tester.js
+++ b/src/plugin-tester.js
@@ -88,6 +88,7 @@ function pluginTester({
         formatResult = r => r,
         fixture,
         testFilepath: testFilename = fixture || filename,
+        verbose,
       } = mergeWith({}, testerConfig, toTestConfig(testConfig), mergeCustomizer)
       assert(
         (!skip && !only) || skip !== only,
@@ -165,6 +166,11 @@ function pluginTester({
           } else {
             throw err
           }
+        }
+
+        if (verbose) {
+          console.log(testFilename)
+          console.log({code, output, result})
         }
 
         const expectedToThrowButDidNot = error && !errored


### PR DESCRIPTION
**What**:

Added a verbose option that allows seeing the input/output of every transformation.

<!-- Why are these changes necessary? -->

**Why**:

Useful during development.

<!-- How were these changes implemented? -->

**How**:

using `console.log`
<!-- feel free to add additional comments -->
