### PR TITLE
fix(pluginNameInference): remove inference. Default to "unknown plugin"

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,7 @@ function identifierReversePlugin() {
 
 #### pluginName
 
-This is used for the `describe` title as well as the test titles. If it can be
-inferred from the `plugin`'s `name` then it will be and you don't need to
-provide this option.
+This is used for the `describe` title as well as the test titles.
 
 #### pluginOptions
 
@@ -221,8 +219,8 @@ this package.
 #### fixtureOutputExt
 
 Use this to provide your own fixture output file extension. This is particularly
-useful if you are testing typescript input. If ommited fixture input file extension
-will be used.
+useful if you are testing typescript input. If ommited fixture input file
+extension will be used.
 
 #### ...rest
 
@@ -588,6 +586,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/__snapshots__/plugin-tester.js.snap
+++ b/src/__tests__/__snapshots__/plugin-tester.js.snap
@@ -4,8 +4,6 @@ exports[`assert throws if code is unchanged + snapshot enabled 1`] = `Code was u
 
 exports[`assert throws if snapshot and output are both provided 1`] = `\`output\` cannot be provided with \`snapshot: true\``;
 
-exports[`assert throws if the plugin name is not inferable 1`] = `The \`pluginName\` must be inferable or provided.`;
-
 exports[`assert throws if there's no code 1`] = `A string or object with a \`code\` or \`fixture\` property must be provided`;
 
 exports[`can fail tests in fixtures at an absolute path 1`] = `actual output does not match output.js`;

--- a/src/__tests__/plugin-tester.js
+++ b/src/__tests__/plugin-tester.js
@@ -72,29 +72,6 @@ test('plugin is required', async () => {
   await expect(runPluginTester()).rejects.toThrowErrorMatchingSnapshot()
 })
 
-test('logs when plugin name is not inferable and rethrows errors', async () => {
-  const error = new Error('hey there')
-  await expect(
-    runPluginTester({
-      plugin: () => {
-        throw error
-      },
-    }),
-  ).rejects.toThrow(error)
-  expect(errorSpy).toHaveBeenCalledTimes(1)
-  expect(errorSpy).toHaveBeenCalledWith(
-    expect.stringMatching(/infer.*name.*plugin/),
-  )
-})
-
-test('assert throws if the plugin name is not inferable', async () => {
-  await expect(
-    runPluginTester({
-      plugin: () => ({}),
-    }),
-  ).rejects.toThrowErrorMatchingSnapshot()
-})
-
 test('exists early if no tests are supplied', async () => {
   const {plugin} = getOptions()
   await runPluginTester({plugin})
@@ -113,16 +90,6 @@ test('accepts a title for the describe block', async () => {
   const title = 'describe block title'
   await runPluginTester(getOptions({title}))
   expect(describeSpy).toHaveBeenCalledWith(title, expect.any(Function))
-})
-
-test('can infer the plugin name for the describe block', async () => {
-  const name = 'super-great'
-  const {plugin, tests} = getOptions({
-    plugin: () => ({name, visitor: {}}),
-  })
-  await runPluginTester({plugin, tests})
-  expect(describeSpy).toHaveBeenCalledTimes(1)
-  expect(describeSpy).toHaveBeenCalledWith(name, expect.any(Function))
 })
 
 test('calls describe and test for a group of tests', async () => {

--- a/src/plugin-tester.js
+++ b/src/plugin-tester.js
@@ -37,7 +37,7 @@ function pluginTester({
   /* istanbul ignore next (TODO: write a test for this) */
   babel = require('@babel/core'),
   plugin = requiredParam('plugin'),
-  pluginName = getPluginName(plugin, babel),
+  pluginName = 'unknown plugin',
   title: describeBlockTitle = pluginName,
   pluginOptions,
   tests,
@@ -440,21 +440,6 @@ function assertError(result, error) {
 
 function requiredParam(name) {
   throw new Error(`${name} is a required parameter.`)
-}
-
-function getPluginName(plugin, babel) {
-  let name
-  try {
-    name = plugin(babel).name
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(
-      'Attempting to infer the name of your plugin failed. Tried to invoke the plugin which threw the error.',
-    )
-    throw error
-  }
-  assert(name, 'The `pluginName` must be inferable or provided.')
-  return name
 }
 
 export default pluginTester


### PR DESCRIPTION


**What**: remove inference. Default to "unknown plugin" 

<!-- Why are these changes necessary? -->

**Why**: Closes #60

<!-- How were these changes implemented? -->

**How**: Remove logic and tests related to inference.

<!-- feel free to add additional comments -->


cc @jayphelps, what do you think? I don't think we need a major version bump here because nobody's build should break with this change.