### PR TITLE
fix: Allow formatting error in snapshot

### DIFF
--- a/src/__tests__/__snapshots__/plugin-tester.js.snap
+++ b/src/__tests__/__snapshots__/plugin-tester.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`allows formatting error in snapshot: 1. captains-log 1`] = `
+
+var hi = "hey";
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+[BABEL] unknown: test message (While processing: "base$0")
+
+`;
+
 exports[`assert throws if code is unchanged + snapshot enabled 1`] = `Code was unmodified but attempted to take a snapshot. If the code should not be modified, set \`snapshot: false\``;
 
 exports[`assert throws if snapshot and output are both provided 1`] = `\`output\` cannot be provided with \`snapshot: true\``;

--- a/src/__tests__/plugin-tester.js
+++ b/src/__tests__/plugin-tester.js
@@ -591,6 +591,28 @@ test('allows formatting fixtures results', async () => {
   expect(formatResultSpy).toHaveBeenCalledTimes(15)
 })
 
+test('allows formatting error in snapshot', async () => {
+  const formatResultSpy = jest.fn(r => r)
+  await runPluginTester(
+    getOptions({
+      plugin: () => {
+        throw new Error('test message')
+      },
+      filename: __filename,
+      tests: [{code: simpleTest, formatResult: formatResultSpy}],
+      snapshot: true,
+      error: true,
+    }),
+  )
+  expect(formatResultSpy).toHaveBeenCalledTimes(1)
+  expect(formatResultSpy).toHaveBeenCalledWith(
+    `[BABEL] unknown: test message (While processing: "base$0")`,
+    {
+      filename: __filename,
+    },
+  )
+})
+
 test('works with a formatter adding a empty line', async () => {
   // Simulate prettier adding an empty line at the end
   const formatResultSpy = jest.fn(r => `${r.trim()}\n\n`)

--- a/src/plugin-tester.js
+++ b/src/plugin-tester.js
@@ -178,6 +178,11 @@ function pluginTester({
             result !== code,
             'Code was unmodified but attempted to take a snapshot. If the code should not be modified, set `snapshot: false`',
           )
+          if (errored) {
+            result = formatResult(result.message, {
+              filename: testFilename,
+            })
+          }
           const separator = '\n\n      ↓ ↓ ↓ ↓ ↓ ↓\n\n'
           const formattedOutput = [code, separator, result].join('')
           expect(`\n${formattedOutput}\n`).toMatchSnapshot(title)


### PR DESCRIPTION
**What**: Allow formatting error in snapshot

**Why**: To be able to normalise saved error message. This happens when you have fixtures expected to fail and you want to snapshot the output. Error message can contains a fullpath to the fixture file. Without the normalisation, tests would fail on CI.

**How**: Pass error message to `formatResult` when error was thrown and snapshots are turned on.
