### PR TITLE
Update comment regarding pluginName in full example

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ pluginTester({
   // required
   plugin: identifierReversePlugin,
 
-  // unnecessary if it's returned with the plugin
+  // will default to 'unknown plugin'
   pluginName: 'identifier reverse',
 
   // defaults to the plugin name


### PR DESCRIPTION
After these changes: https://github.com/babel-utils/babel-plugin-tester/commit/91c22ecc29598db2a99b16df29d986087e9cd1b4
It's no longer true that `pluginName` is unnecessary :-)
