### PR TITLE
use babel.transformAsync when it's available

### DIFF
--- a/src/__tests__/plugin-tester.js
+++ b/src/__tests__/plugin-tester.js
@@ -52,7 +52,7 @@ beforeEach(() => {
   global.it.skip = jest.fn(titleTesterMock)
   itOnlySpy = global.it.only
   itSkipSpy = global.it.skip
-  transformSpy = jest.spyOn(babel, 'transform')
+  transformSpy = jest.spyOn(babel, 'transformAsync')
   writeFileSyncSpy = jest
     .spyOn(fs, 'writeFileSync')
     .mockImplementation(() => {})
@@ -367,6 +367,24 @@ test('can provide a test filename for code strings', async () => {
       filename,
     }),
   )
+})
+
+test('works with versions of babel without `.transformSync` method', async () => {
+  const tests = [simpleTest]
+  const oldBabel = {
+    transform: babel.transform,
+  }
+  const transformSyncSpy = jest.spyOn(oldBabel, 'transform')
+  await runPluginTester(
+    getOptions({
+      babel: oldBabel,
+      filename: __filename,
+      fixtures: 'fixtures/fixtures',
+      tests,
+    }),
+  )
+  expect(transformSpy).not.toHaveBeenCalled()
+  expect(transformSyncSpy).toHaveBeenCalledTimes(15)
 })
 
 test('can provide plugin options', async () => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Fixes https://github.com/babel-utils/babel-plugin-tester/issues/83

**What**:

<!-- Why are these changes necessary? -->
Uses `babel.transformAsync` by default.

**Why**:

To support async babel plugins.
<!-- How were these changes implemented? -->

**How**:

Check for the existence of `babel.transformAsync`, and fall back to `babel.transform` if necessary.
<!-- feel free to add additional comments -->
