### PR TITLE
fix(src): fix plugin run order for fixtures to match tests

### DIFF
--- a/src/plugin-tester.js
+++ b/src/plugin-tester.js
@@ -307,24 +307,28 @@ const createFixtureTests = (fixturesDir, options) => {
         ...rest
       } = options
 
-      const hasBabelrc = [
-        '.babelrc',
-        '.babelrc.js',
-        '.babelrc.cjs',
-      ].some(babelrc => fs.existsSync(path.join(fixtureDir, babelrc)))
+      const hasBabelrc = ['.babelrc', '.babelrc.js', '.babelrc.cjs'].some(
+        babelrc => fs.existsSync(path.join(fixtureDir, babelrc)),
+      )
 
       const {babelOptions} = mergeWith(
         {},
         fullDefaultConfig,
         {
           babelOptions: {
-            plugins: [[plugin, mergedFixtureAndPluginOptions]],
             // if they have a babelrc, then we'll let them use that
             // otherwise, we'll just use our simple config
             babelrc: hasBabelrc,
           },
         },
         rest,
+        {
+          babelOptions: {
+            // Ensure `rest` comes before `babelOptions.plugins` to preserve
+            // default plugin run order
+            plugins: [[plugin, mergedFixtureAndPluginOptions]],
+          },
+        },
         mergeCustomizer,
       )
 


### PR DESCRIPTION
Closes #74

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: As stated in #74, plugins are run in a different order in fixtures vs in tests. I confirmed this behavior with a [new unit test](https://github.com/babel-utils/babel-plugin-tester/compare/master...Xunnamius:babel-plugin-tester:contrib-fix-plugin-run-order-for-fixtures?expand=1#diff-253e8230e711a2052517dc6d606c4485422291d9aef90b8bcde6086fa2cbf78aR732-R765). This PR fixes the problem.

<!-- Why are these changes necessary? -->

**Why**: Aside from being unlike how babel would invoke the plugin in real life, running plugins in inconsistent sequences can lead to [surprising behavior](https://github.com/babel-utils/babel-plugin-tester/issues/74) and brittle tests. Also, it makes [specifying a consistent custom plugin loading order](https://github.com/babel-utils/babel-plugin-tester/pull/91) more difficult to reason about.

<!-- How were these changes implemented? -->

**How**: The problem is that, for fixtures, `babelOptions.plugins` (containing the plugin under test) comes before `options.babelOptions.plugins` (containing user-supplied plugins) in the [mergeWith](https://lodash.com/docs/4.17.15#mergeWith) function call, resulting in the user-supplied plugins appearing last in the final `babelOptions.plugins` array. This PR [reverses that ordering for fixtures specifically](https://github.com/babel-utils/babel-plugin-tester/compare/master...Xunnamius:babel-plugin-tester:contrib-fix-plugin-run-order-for-fixtures?expand=1#diff-493fa057af0f000faf7ce45becbbe2ced9bab231e9e357e70dd00d62beea0710R319-R328) such that the user-supplied plugins are run before the plugin under test, which is the order used by the `tests` option and [by babel itself](https://babeljs.io/docs/en/plugins/#plugin-ordering).

<!-- feel free to add additional comments -->