### PR TITLE
fix(src): fix fixtureOutputExt being ignored in root options.json

### DIFF
--- a/src/__tests__/__snapshots__/plugin-tester.js.snap
+++ b/src/__tests__/__snapshots__/plugin-tester.js.snap
@@ -32,6 +32,6 @@ exports[`throws error if fixture provided and code changes 1`] = `Expected outpu
 
 exports[`throws error when error expected but no error thrown 1`] = `Expected to throw error, but it did not.`;
 
-exports[`throws error when function doesn't return true 1`] = `[BABEL] unknown: test message (While processing: "base$0")`;
+exports[`throws error when function doesn't return true 1`] = `[BABEL] unknown file: test message (While processing: "base$0")`;
 
 exports[`throws if output is incorrect 1`] = `Output is incorrect.`;

--- a/src/__tests__/fixtures/fixtureOutputExt/fixture/code.ts
+++ b/src/__tests__/fixtures/fixtureOutputExt/fixture/code.ts
@@ -1,0 +1,1 @@
+'use strict';

--- a/src/__tests__/fixtures/fixtureOutputExt/fixture/options.json
+++ b/src/__tests__/fixtures/fixtureOutputExt/fixture/options.json
@@ -1,0 +1,1 @@
+{"fixtureOutputExt": ".js"}

--- a/src/__tests__/fixtures/fixtureOutputExt/fixture/output.js
+++ b/src/__tests__/fixtures/fixtureOutputExt/fixture/output.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/src/__tests__/fixtures/root-fixtureOutputExt/root/fixture/code.ts
+++ b/src/__tests__/fixtures/root-fixtureOutputExt/root/fixture/code.ts
@@ -1,0 +1,1 @@
+'use strict';

--- a/src/__tests__/fixtures/root-fixtureOutputExt/root/fixture/output.js
+++ b/src/__tests__/fixtures/root-fixtureOutputExt/root/fixture/output.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/src/__tests__/fixtures/root-fixtureOutputExt/root/options.json
+++ b/src/__tests__/fixtures/root-fixtureOutputExt/root/options.json
@@ -1,0 +1,1 @@
+{"fixtureOutputExt": ".js"}

--- a/src/__tests__/plugin-tester.js
+++ b/src/__tests__/plugin-tester.js
@@ -639,7 +639,7 @@ test('prettier formatter supported', async () => {
   )
 })
 
-test('gets options from options.json files when using fixtures', async () => {
+test('gets options from local and root options.json files when using fixtures', async () => {
   const optionRootFoo = jest.fn()
   const optionFoo = jest.fn()
   const optionBar = jest.fn()
@@ -671,6 +671,40 @@ test('gets options from options.json files when using fixtures', async () => {
   expect(optionRootFoo).toHaveBeenCalledTimes(14)
   expect(optionFoo).toHaveBeenCalledTimes(2)
   expect(optionBar).toHaveBeenCalledTimes(1)
+})
+
+test('respects fixtureOutputExt from root options.json file when using fixtures', async () => {
+  await runPluginTester(
+    getOptions({
+      fixtures: getFixturePath('root-fixtureOutputExt'),
+      tests: null,
+    }),
+  )
+
+  expect(writeFileSyncSpy).toHaveBeenCalledTimes(0)
+
+  expect(equalSpy).toHaveBeenCalledWith(
+    getFixtureContents('root-fixtureOutputExt/root/fixture/code.ts'),
+    getFixtureContents('root-fixtureOutputExt/root/fixture/output.js'),
+    expect.any(String),
+  )
+})
+
+test('respects fixtureOutputExt from local options.json file when using fixtures', async () => {
+  await runPluginTester(
+    getOptions({
+      fixtures: getFixturePath('fixtureOutputExt'),
+      tests: null,
+    }),
+  )
+
+  expect(writeFileSyncSpy).toHaveBeenCalledTimes(0)
+
+  expect(equalSpy).toHaveBeenCalledWith(
+    getFixtureContents('fixtureOutputExt/fixture/code.ts'),
+    getFixtureContents('fixtureOutputExt/fixture/output.js'),
+    expect.any(String),
+  )
 })
 
 test('appends to root plugins array', async () => {

--- a/src/plugin-tester.js
+++ b/src/plugin-tester.js
@@ -275,20 +275,22 @@ const createFixtureTests = (fixturesDir, options) => {
       (fs.existsSync(tsCodePath) && tsCodePath) ||
       (fs.existsSync(jsxCodePath) && jsxCodePath) ||
       (fs.existsSync(tsxCodePath) && tsxCodePath)
-    let fixturePluginOptions = {}
+    let localFixtureOptions = {}
     if (fs.existsSync(optionsPath)) {
-      fixturePluginOptions = require(optionsPath)
+      localFixtureOptions = require(optionsPath)
+    }
+
+    const mergedFixtureAndPluginOptions = {
+      ...rootFixtureOptions,
+      ...options.pluginOptions,
+      ...localFixtureOptions,
     }
 
     if (!codePath) {
       describe(blockTitle, () => {
         createFixtureTests(fixtureDir, {
           ...options,
-          pluginOptions: {
-            ...rootFixtureOptions,
-            ...options.pluginOptions,
-            ...fixturePluginOptions,
-          },
+          pluginOptions: mergedFixtureAndPluginOptions,
         })
       })
       return
@@ -316,16 +318,7 @@ const createFixtureTests = (fixturesDir, options) => {
         fullDefaultConfig,
         {
           babelOptions: {
-            plugins: [
-              [
-                plugin,
-                {
-                  ...rootFixtureOptions,
-                  ...pluginOptions,
-                  ...fixturePluginOptions,
-                },
-              ],
-            ],
+            plugins: [[plugin, mergedFixtureAndPluginOptions]],
             // if they have a babelrc, then we'll let them use that
             // otherwise, we'll just use our simple config
             babelrc: hasBabelrc,
@@ -352,7 +345,8 @@ const createFixtureTests = (fixturesDir, options) => {
         fixLineEndings(transformed.code, endOfLine, input),
       )
 
-      const {fixtureOutputExt} = fixturePluginOptions
+      const {fixtureOutputExt} = mergedFixtureAndPluginOptions
+
       if (fixtureOutputExt) {
         ext = fixtureOutputExt
       } else {


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: The `fixtureOutputExt` option works when it appears in a local `options.json` file but is ignored if it appears in a root `options.json` file even though [the docs claim that root options.json configurations are inherited](https://github.com/babel-utils/babel-plugin-tester#fixtures). This PR ensures `fixtureOutputExt` is no longer ignored in root `options.json`.

<!-- Why are these changes necessary? -->

**Why**: Sometimes it's necessary to specify different values for `fixtureOutputExt` across different fixtures. Other times, like when working in TypeScript projects, it's nice to be able to specify a single overridable default (like `.js` or `.mjs`) in one place instead of across ~100 otherwise-empty `options.json` files nestled away in fixture subdirectories.

<!-- How were these changes implemented? -->

**How**: By ensuring `fixtureOutputExt` is [pulled from the merged fixture options object](https://github.com/babel-utils/babel-plugin-tester/compare/master...Xunnamius:babel-plugin-tester:contrib-fix-root-options-json?expand=1#diff-493fa057af0f000faf7ce45becbbe2ced9bab231e9e357e70dd00d62beea0710R348-R349) instead of just the local fixture options object.

<!-- feel free to add additional comments -->

Additionally, in the [accompanying PR for updating the README](https://github.com/babel-utils/babel-plugin-tester/pull/93), I've grouped `fixtureOutputExt` with the `fixtures` option and updated its description to be a little clearer.