### PR TITLE
feat(src): add support for arbitrary run order of plugin under test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import pluginTester from './plugin-tester'
+import pluginTester, {runPluginUnderTestHere} from './plugin-tester'
 import prettierFormatter from './formatters/prettier'
 import unstringSnapshotSerializer from './unstring-snapshot-serializer'
 
@@ -7,7 +7,7 @@ if (typeof expect !== 'undefined' && expect.addSnapshotSerializer) {
   expect.addSnapshotSerializer(unstringSnapshotSerializer)
 }
 
-export {unstringSnapshotSerializer, prettierFormatter}
+export {unstringSnapshotSerializer, prettierFormatter, runPluginUnderTestHere}
 
 function defaultPluginTester(options) {
   return pluginTester({formatResult: prettierFormatter, ...options})

--- a/src/plugin-tester.js
+++ b/src/plugin-tester.js
@@ -5,6 +5,8 @@ import {EOL} from 'os'
 import mergeWith from 'lodash.mergewith'
 import stripIndent from 'strip-indent'
 
+export const runPluginUnderTestHere = Symbol('run-plugin-under-test-here')
+
 const noop = () => {}
 
 // thanks to node throwing an error if you try to use instanceof with an arrow
@@ -93,6 +95,8 @@ function pluginTester({
         (!skip && !only) || skip !== only,
         'Cannot enable both skip and only on a test',
       )
+
+      finalizePluginRunOrder(babelOptions)
 
       if (skip) {
         // eslint-disable-next-line jest/no-disabled-tests
@@ -332,6 +336,8 @@ const createFixtureTests = (fixturesDir, options) => {
         mergeCustomizer,
       )
 
+      finalizePluginRunOrder(babelOptions)
+
       const input = fs.readFileSync(codePath).toString()
       let transformed, ext
       if (babel.transformAsync) {
@@ -445,6 +451,16 @@ function assertError(result, error) {
 
 function requiredParam(name) {
   throw new Error(`${name} is a required parameter.`)
+}
+
+function finalizePluginRunOrder(babelOptions) {
+  if (babelOptions.plugins.includes(runPluginUnderTestHere)) {
+    babelOptions.plugins.splice(
+      babelOptions.plugins.indexOf(runPluginUnderTestHere),
+      1,
+      babelOptions.plugins.pop(),
+    )
+  }
 }
 
 export default pluginTester


### PR DESCRIPTION
Closes #76
Solves #18

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: As requested in #76, this PR allows users to specify in what order babel will run the plugin under test with respect to the plugins passed via `options.babelOptions.plugins`.

<!-- Why are these changes necessary? -->

**Why**: Sometimes you need a plugin to run before certain plugins but/or after others, as demonstrated in #76.

<!-- How were these changes implemented? -->

**How**: Users can import a [symbol well-known to babel-plugin-tester](https://github.com/babel-utils/babel-plugin-tester/compare/master...Xunnamius:babel-plugin-tester:contrib-feat-arbitrary-run-order?expand=1#diff-493fa057af0f000faf7ce45becbbe2ced9bab231e9e357e70dd00d62beea0710R8) that, if encountered in `options.babelOptions.plugins`, [will be replaced by the plugin under test](https://github.com/babel-utils/babel-plugin-tester/compare/master...Xunnamius:babel-plugin-tester:contrib-feat-arbitrary-run-order?expand=1#diff-493fa057af0f000faf7ce45becbbe2ced9bab231e9e357e70dd00d62beea0710R464-R473).

<!-- feel free to add additional comments -->

Note that this PR is built on top of #88, so merging this PR will also result in #88 being merged too.

Additionally, in the [accompanying PR for updating the README](https://github.com/babel-utils/babel-plugin-tester/pull/93), I've rewritten the `babelOptions` section to be clearer and more accurate, and added a blurb about this feature in a subsection. Also, this PR will require an update to the [TypeScript types package for `babel-plugin-tester`](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/babel-plugin-tester) to include the new symbol export. If this PR is accepted, I'll submit a corresponding PR to DefinitelyTyped.