### PR TITLE
feat(src): bring back (lightweight) plugin name inference

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
+    "@babel/helper-plugin-utils": "^7.19.0",
     "@babel/plugin-proposal-async-generator-functions": "^7.10.5",
     "@babel/plugin-syntax-jsx": "^7.10.4",
     "@babel/plugin-syntax-typescript": "^7.10.4",
     "@babel/plugin-transform-async-to-generator": "^7.10.4",
     "@babel/preset-env": "^7.11.5",
+    "@types/babel__helper-plugin-utils": "^7.10.0",
     "kcd-scripts": "^6.5.1"
   },
   "peerDependencies": {

--- a/src/__tests__/plugin-tester.js
+++ b/src/__tests__/plugin-tester.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import assert from 'assert'
 import {EOL} from 'os'
+import {declare} from '@babel/helper-plugin-utils'
 import pluginTester, {runPluginUnderTestHere} from '../plugin-tester'
 import prettierFormatter from '../formatters/prettier'
 import unstringSnapshotSerializer from '../unstring-snapshot-serializer'
@@ -96,7 +97,79 @@ test('exits early if tests is an empty array', async () => {
   expect(itSpy).not.toHaveBeenCalled()
 })
 
-test('accepts a title for the describe block', async () => {
+test('uses inferred plugin name as title if available otherwise uses default', async () => {
+  await runPluginTester(
+    getOptions({
+      pluginName: undefined,
+      plugin: () => ({name: 'captains-journal', visitor: {}}),
+    }),
+  )
+  expect(describeSpy).toHaveBeenCalledTimes(1)
+  expect(describeSpy).toHaveBeenCalledWith(
+    'captains-journal',
+    expect.any(Function),
+  )
+})
+
+test('can infer plugin name from packages using @babel/helper-plugin-utils', async () => {
+  await runPluginTester(
+    getOptions({
+      pluginName: undefined,
+      plugin: declare((api, options, dirname) => {
+        api.assertVersion(7)
+        api.targets()
+        api.assumption('some-assumption')
+
+        const {version} = options
+        assert(dirname, 'expected dirname to be polyfilled (defined)')
+        assert(!version, 'expected version to be polyfilled (undefined)')
+
+        return {name: 'captains-journal', visitor: {}}
+      }),
+    }),
+  )
+  expect(describeSpy).toHaveBeenCalledWith(
+    'captains-journal',
+    expect.any(Function),
+  )
+})
+
+test('uses "unknown plugin" without crashing if plugin crashes while inferring name', async () => {
+  let called = false
+
+  await runPluginTester(
+    getOptions({
+      pluginName: undefined,
+      plugin: () => {
+        if (called) {
+          return {visitor: {}}
+        } else {
+          called = true
+          throw new Error('plugin crashed was unhandled')
+        }
+      },
+    }),
+  )
+  expect(describeSpy).toHaveBeenCalledWith(
+    'unknown plugin',
+    expect.any(Function),
+  )
+})
+
+test('uses "unknown plugin" if no custom title or plugin name is available', async () => {
+  await runPluginTester(
+    getOptions({
+      pluginName: undefined,
+      plugin: () => ({visitor: {}}),
+    }),
+  )
+  expect(describeSpy).toHaveBeenCalledWith(
+    'unknown plugin',
+    expect.any(Function),
+  )
+})
+
+test('accepts a custom title for the describe block', async () => {
   const title = 'describe block title'
   await runPluginTester(getOptions({title}))
   expect(describeSpy).toHaveBeenCalledWith(title, expect.any(Function))

--- a/src/plugin-tester.js
+++ b/src/plugin-tester.js
@@ -39,8 +39,8 @@ function pluginTester({
   /* istanbul ignore next (TODO: write a test for this) */
   babel = require('@babel/core'),
   plugin = requiredParam('plugin'),
-  pluginName = 'unknown plugin',
-  title: describeBlockTitle = pluginName,
+  pluginName,
+  title: describeBlockTitle,
   pluginOptions,
   tests,
   fixtures,
@@ -49,6 +49,22 @@ function pluginTester({
   endOfLine = 'lf',
   ...rest
 } = {}) {
+  const tryInferPluginName = () => {
+    try {
+      // https://github.com/babel/babel/blob/abb26aaac2c0f6d7a8a8a1d03cde3ebc5c3c42ae/packages/babel-helper-plugin-utils/src/index.ts#L53-L70
+      return plugin(
+        {assertVersion: () => {}, targets: () => ({}), assumption: () => {}},
+        {},
+        process.cwd(),
+      ).name
+    } catch {
+      return undefined
+    }
+  }
+
+  pluginName = pluginName || tryInferPluginName() || 'unknown plugin'
+  describeBlockTitle = describeBlockTitle || pluginName
+
   let testNumber = 1
   if (fixtures) {
     testFixtures({


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: This PR brings back the `pluginName` inference functionality that was removed in #78. The new inference functionality is "lightweight" (in that it never throws or emits an error upon failure), addresses the concerns raised in #58 and #60, and maintains the `"unknown plugin"` determination as a fallback.

Also, even though this PR probably doesn't break anything since it falls back to the current `"unknown plugin"` functionality upon failure, it might be considered a breaking change for the same reason #78 was.

<!-- Why are these changes necessary? -->

**Why**: Because the developer experience was greatly improved by `pluginName` inference in my personal experience. I have a lot of shared/copy-pasted configurations, and it can be easy to forget to change the `pluginName` value manually when switching between babel plugin projects or creating new ones based on old config. This leads to confusing error messages and logs that are slightly more annoying to parse in heavily automated environments.

<!-- How were these changes implemented? -->

**How**: [The inference logic is wrapped in a try-catch where any errors are caught and ignored](https://github.com/babel-utils/babel-plugin-tester/compare/master...Xunnamius:babel-plugin-tester:contrib-feat-lightweight-inference?expand=1#diff-493fa057af0f000faf7ce45becbbe2ced9bab231e9e357e70dd00d62beea0710R50-R64). In the case where an error occurs, or when the plugin does not return a name, `"unknown plugin"` is used instead.

Using [source](https://github.com/babel/babel/blob/abb26aaac2c0f6d7a8a8a1d03cde3ebc5c3c42ae/packages/babel-helper-plugin-utils/src/index.ts#L53-L70) from @babel/helper-plugin-utils as a reference, I stubbed out the most useful [babel api functions](https://babeljs.io/docs/en/config-files#config-function-api) so that the inference logic would fail less often. However, **it is not important that this api is kept up to date or that the plugin under test might crash during inference**, since when the inference logic fails `"unknown plugin"` will be returned without incident. I added [tests](https://github.com/babel-utils/babel-plugin-tester/compare/master...Xunnamius:babel-plugin-tester:contrib-feat-lightweight-inference?expand=1#diff-253e8230e711a2052517dc6d606c4485422291d9aef90b8bcde6086fa2cbf78aR90-R162) for this functionality.

I also added a [test](https://github.com/babel-utils/babel-plugin-tester/compare/master...Xunnamius:babel-plugin-tester:contrib-feat-lightweight-inference?expand=1#diff-253e8230e711a2052517dc6d606c4485422291d9aef90b8bcde6086fa2cbf78aR104-R125) that ensures `pluginName` inference works even when testing a plugin built with @babel/helper-plugin-utils and/or using the most [common babel `api` features](https://babeljs.io/docs/en/config-files#config-function-api) like `assertVersion` (this was the primary concern of #58 and #60). This way, even when `assertVersion` is used outside of the returned visitor object, `pluginName` will be inferred successfully!

<!-- feel free to add additional comments -->

Additionally, in the [accompanying PR for updating the README](https://github.com/babel-utils/babel-plugin-tester/pull/93), I've added back some of the language that talked about `pluginName` potentially being inferred. I also added a section at the bottom that talks about a caveat with relying on lightweight inference, but, as far as I can tell, the new inference functionality would only be problematic for very poorly authored plugins. I expand on this more in the caveat section.

Honestly, the motivation for this PR was that, when I was using this plugin in a TypeScript environment, the type hint for `pluginName` told me that the plugin name could be inferred, which made me happy, but then I was surprised when it didn't work. So, if this PR is rejected, updating the TypeScript type to [remove the erroneous verbiage](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/babel-plugin-tester/index.d.ts#L193) should be considered. Either way, I'd be willing to submit a PR updating the TypeScript types package, since #91 requires updated types anyway. Let me know!